### PR TITLE
Re-enables push triggers for workflow

### DIFF
--- a/.github/workflows/on-update.yaml
+++ b/.github/workflows/on-update.yaml
@@ -1,10 +1,9 @@
 name: On Update documentation
 
 on:
-  workflow_dispatch: {}
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 */10 * *'
 
 jobs:
   refresh-context7:

--- a/.github/workflows/on-update.yaml
+++ b/.github/workflows/on-update.yaml
@@ -2,6 +2,9 @@ name: On Update documentation
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
   schedule:
     - cron: '0 0 */10 * *'
 


### PR DESCRIPTION
Re-enables push triggers on the `main` branch for the documentation update workflow.
This ensures documentation updates are triggered on push events, in addition to the scheduled and manual triggers.