### PR TITLE
Adds Vale for linting and vocabulary support

### DIFF
--- a/config/vocabularies/Blaxel/accept.txt
+++ b/config/vocabularies/Blaxel/accept.txt
@@ -1,0 +1,16 @@
+[Bb]laxel
+checkpointer
+scaffolded
+[Cc]opilotkit
+[Aa]gentic
+serverless
+sandboxed
+VM
+Agentics
+[Tt]oolprint
+[Zz]endesk
+[Qq]drant
+[Ee]xa
+[Ss]torying
+sudo
+withSpan

--- a/vale.ini
+++ b/vale.ini
@@ -1,0 +1,32 @@
+# Top level styles
+StylesPath = /app/styles
+MinAlertLevel = suggestion
+IgnoredScopes = code, tt, img, url, a
+SkippedScopes = script, style, pre, figure, code
+
+# Vocabularies
+Vocab = Mintlify, Blaxel, checkpointer, scaffolded, copilotkit, agentic, serverless, sandboxed, VM, Agentics, Toolprint, Zendesk, Qdrant, Exa, storying, sudo, withSpan
+
+# This is required since Vale doesn't officially support MDX
+[formats]
+mdx = md
+
+# MDX support
+[*.mdx]
+BasedOnStyles = Vale
+Vale.Terms = NO # Enforces really harsh capitalization rules, keep off
+
+# `import ...`, `export ...`
+# `<Component ... />`
+# `<Component>...</Component>`
+# `{ ... }`
+TokenIgnores = (?sm)((?:import|export) .+?$), \
+(?<!`)(<\w+ ?.+ ?\/>)(?!`), \
+(<[A-Z]\w+>.+?<\/[A-Z]\w+>)
+
+# Exclude:
+# `<Component \n ... />`
+BlockIgnores = (?sm)^(<\w+\n .*\s\/>)$, \
+(?sm)^({.+.*})
+
+CommentDelimiters = {/*, */}


### PR DESCRIPTION
Adds Vale configuration and vocabulary files to enforce consistent terminology and style in the documentation. This ensures that terms like "Blaxel" and "CopilotKit" are consistently capitalized and used correctly.