### PR TITLE
docs: update text and code for dynamic port provisioning

### DIFF
--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -250,10 +250,10 @@ The following ports are reserved by Blaxel's system:
 - **80**: Reserved for system operations
 - **8080**: Reserved for sandbox API functionality
 
-You can expose specific non-reserved ports [**when creating a new sandbox**](Overview) by using the `ports` parameter. This allows you to access these ports from outside the sandbox.
+You can expose specific non-reserved ports [**when creating a new sandbox**](/Sandboxes/Overview) by using the `ports` parameter. This allows you to access these ports from outside the sandbox via the sandbox API.
 
 <Note>
-  If you plan to access the sandbox on a specific port, typically using a [preview URL](/Sandboxes/Preview-url), you **must** expose the port at sandbox creation time. It is currently not possible to expose sandbox ports post-creation.
+  You only need to expose ports at sandbox creation time if you plan to access the port via the sandbox API. For access via preview URL, ports are dynamically opened as needed.
 </Note>
 
 ### Regions

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -253,7 +253,7 @@ The following ports are reserved by Blaxel's system:
 You can expose specific non-reserved ports [**when creating a new sandbox**](/Sandboxes/Overview) by using the `ports` parameter. This allows you to access these ports from outside the sandbox via the sandbox API.
 
 <Note>
-  You only need to expose ports at sandbox creation time if you plan to access the port via the sandbox API. For access via preview URL, ports are dynamically opened as needed.
+  You only need to expose ports at sandbox creation time if you plan to access the port via the sandbox API. For access via [preview URL](./Preview-url), ports are dynamically opened as needed.
 </Note>
 
 ### Regions

--- a/Sandboxes/Ports.mdx
+++ b/Sandboxes/Ports.mdx
@@ -24,7 +24,7 @@ You can expose and use any other port on your sandbox.
 To whitelist sandbox traffic in your network, you can [retrieve the public IP addresses](/Infrastructure/Regions#public-ip-addresses) used by Blaxel.
 </Note>
 
-You can expose specific non-reserved ports [**when creating a new sandbox**](Overview) by using the `ports` parameter. This allows you to access these ports from outside the sandbox via the sandbox API.
+You can expose specific non-reserved ports [**when creating a new sandbox**](/Sandboxes/Overview) by using the `ports` parameter. This allows you to access these ports from outside the sandbox via the sandbox API.
 
 <Note>
   You only need to expose ports at sandbox creation time if you plan to access the port via the sandbox API. For access via preview URL, ports are dynamically opened as needed.

--- a/Sandboxes/Ports.mdx
+++ b/Sandboxes/Ports.mdx
@@ -24,10 +24,10 @@ You can expose and use any other port on your sandbox.
 To whitelist sandbox traffic in your network, you can [retrieve the public IP addresses](/Infrastructure/Regions#public-ip-addresses) used by Blaxel.
 </Note>
 
-You can expose specific non-reserved ports [**when creating a new sandbox**](Overview) by using the `ports` parameter. This allows you to access these ports from outside the sandbox.
+You can expose specific non-reserved ports [**when creating a new sandbox**](Overview) by using the `ports` parameter. This allows you to access these ports from outside the sandbox via the sandbox API.
 
 <Note>
-  If you plan to access the sandbox on a specific port, typically using a [preview URL](/Sandboxes/Preview-url), you **must** expose the port at sandbox creation time. It is currently not possible to expose sandbox ports post-creation.
+  You only need to expose ports at sandbox creation time if you plan to access the port via the sandbox API. For access via preview URL, ports are dynamically opened as needed.
 </Note>
 
 <CodeGroup>

--- a/Sandboxes/Ports.mdx
+++ b/Sandboxes/Ports.mdx
@@ -27,7 +27,7 @@ To whitelist sandbox traffic in your network, you can [retrieve the public IP ad
 You can expose specific non-reserved ports [**when creating a new sandbox**](/Sandboxes/Overview) by using the `ports` parameter. This allows you to access these ports from outside the sandbox via the sandbox API.
 
 <Note>
-  You only need to expose ports at sandbox creation time if you plan to access the port via the sandbox API. For access via preview URL, ports are dynamically opened as needed.
+  You only need to expose ports at sandbox creation time if you plan to access the port via the sandbox API. For access via [preview URL](./Preview-url), ports are dynamically opened as needed.
 </Note>
 
 <CodeGroup>

--- a/Sandboxes/Sessions.mdx
+++ b/Sandboxes/Sessions.mdx
@@ -101,10 +101,7 @@ export async function GET() {
     name: SANDBOX_NAME,
     image: "blaxel/base-image:latest",
     memory: 4096,
-    region: "us-pdx-1",
-    ports: [
-      { name: "preview", target: 3000 }
-    ]
+    region: "us-pdx-1"
   });
 
   // Create session (24 hours expiry)

--- a/Tutorials/Astro.mdx
+++ b/Tutorials/Astro.mdx
@@ -163,9 +163,6 @@ const sandbox = await SandboxInstance.createIfNotExists({
   },
   image: "astro-template:latest",
   memory: 4096,
-  ports: [
-    { name: "preview", target: 4321, protocol: "HTTP" },
-  ],
 });
 ```
 
@@ -290,9 +287,6 @@ async function main() {
       },
       image: "astro-template:latest",
       memory: 4096,
-      ports: [
-        { name: "preview", target: 4321, protocol: "HTTP" },
-      ]
     });
 
     // Create preview

--- a/Tutorials/Claude-Code.mdx
+++ b/Tutorials/Claude-Code.mdx
@@ -86,7 +86,6 @@ Before starting, ensure you have:
         name: "nextjs-sandbox",
         image: "blaxel/nextjs:latest",
         memory: 4096,
-        ports: [{ target: 3000, protocol: "HTTP" }],
         region: "us-pdx-1",
       });
       console.log("Application sandbox created");
@@ -154,7 +153,6 @@ Before starting, ensure you have:
             "name": "nextjs-sandbox",
             "image": "blaxel/nextjs:latest",
             "memory": 4096,
-            "ports": [{ "target": 3000, "protocol": "HTTP" }],
             "region": "us-pdx-1",
         })
         print("Application sandbox created")

--- a/Tutorials/Expo.mdx
+++ b/Tutorials/Expo.mdx
@@ -104,9 +104,6 @@ const sandbox = await SandboxInstance.createIfNotExists({
   },
   image: "expo-template:latest",
   memory: 8096,
-  ports: [
-    { name: "preview", target: 8081, protocol: "HTTP" },
-  ],
 });
 ```
 
@@ -377,9 +374,6 @@ async function main() {
       },
       image: "expo-template:latest",
       memory: 8096,
-      ports: [
-        { name: "preview", target: 8081, protocol: "HTTP" },
-      ]
     });
 
     // Create preview

--- a/Tutorials/Nextjs.mdx
+++ b/Tutorials/Nextjs.mdx
@@ -164,9 +164,6 @@ const sandbox = await SandboxInstance.createIfNotExists({
   },
   image: "nextjs-template:latest",
   memory: 4096,
-  ports: [
-    { name: "preview", target: 3000, protocol: "HTTP" },
-  ],
 });
 ```
 
@@ -291,9 +288,6 @@ async function main() {
       },
       image: "nextjs-template:latest",
       memory: 4096,
-      ports: [
-        { name: "preview", target: 3000, protocol: "HTTP" },
-      ]
     });
 
     // Create preview

--- a/Tutorials/OpenClaw.mdx
+++ b/Tutorials/OpenClaw.mdx
@@ -49,7 +49,6 @@ Before starting, ensure you have:
             "name": "openclaw-sandbox",
             "image": "blaxel/node:latest",
             "memory": 4096,
-            "ports": [{ "target": 18789, "protocol": "HTTP" }],
             "region": "us-pdx-1",
         })
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -19,6 +19,14 @@ Added `bl push` command to build and push a container image to the Blaxel regist
 
 </Update>
 
+<Update label="2026-03-31">
+
+### Dynamic port provisoning for sandbox previews
+
+Ports for previews no longer need to be configured at sandbox creation time. They are now opened dynamically on preview creation.
+
+</Update>
+
 <Update label="2026-03-26">
 
 ### New proxy and network features


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Updates documentation to reflect dynamic port provisioning for preview URLs: removes `ports` parameters from code examples across tutorial files, fixes link paths to use absolute routes, clarifies that port pre-declaration is only required for sandbox API access, and adds a changelog entry.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 280c80c4c6bcae16519395b2d5ca59209697649e.</sup>
<!-- /MENDRAL_SUMMARY -->