### PR TITLE
docs: add drive path warning for agent drive

### DIFF
--- a/Agent-drive/Overview.mdx
+++ b/Agent-drive/Overview.mdx
@@ -5,7 +5,7 @@ tag: "private preview"
 ---
 
 <Note>
-  This feature is currently in private preview. During the preview, the Agent Drive feature is only available in the `us-was-1` region. Both your drive and your sandbox must be created in this region. Drive size is not configurable at the moment. A quotas system for drive storage is coming soon. [Request access](https://blaxel.fillout.com/t/pbTXmanx3Sus).
+  This feature is currently in private preview. During the preview, the Agent Drive feature is only available in the `us-was-1` region. Both your drive and your sandbox must be created in this region. Drive size is not configurable at the moment. Similarly, drive access control is currently only possible at workspace level: once a drive is mounted in a sandbox, the sandbox has sufficient credentials to access all other drives in the same workspace. A quotas system for drive storage and more fine-grained access control features are coming soon. [Request access](https://blaxel.fillout.com/t/pbTXmanx3Sus).
 </Note>
 
 Agent Drive is a distributed filesystem that can be mounted to multiple sandboxes or agents at any time, including while they are already running. Drives support concurrent read-write access (RWX) from multiple sandboxes simultaneously, with built-in replication for durability.
@@ -159,7 +159,7 @@ await sandbox.drives.mount(
 </CodeGroup>
 
 <Warning>
-  `drivePath` / `drive_path` is a mount point convenience, not a security boundary. Once a drive is mounted at any location in a sandbox, the sandbox has sufficient credentials to mount any other path on the same drive.
+  `drivePath` / `drive_path` is a mount point convenience, not a security boundary. Once a drive is mounted at any location in a sandbox, the sandbox has sufficient credentials to access all other drives in the same workspace. This is a temporary constraint during the preview phase; the final release will include fine-grained access control.
 </Warning>
 
 ## List mounted drives

--- a/Agent-drive/Overview.mdx
+++ b/Agent-drive/Overview.mdx
@@ -158,6 +158,10 @@ await sandbox.drives.mount(
 
 </CodeGroup>
 
+<Warning>
+  `drivePath` / `drive_path` is a mount point convenience, not a security boundary. Once a drive is mounted at any location in a sandbox, the sandbox has sufficient credentials to mount any other path on the same drive.
+</Warning>
+
 ## List mounted drives
 
 List all drives currently mounted to a sandbox:


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `<Warning>` callout clarifying that `drivePath`/`drive_path` is a mount point convenience rather than a security boundary, and expands the preview `<Note>` to mention workspace-level access control limitations.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 13689d0d835a7717f0c910a6a7a075f996821dd5.</sup>
<!-- /MENDRAL_SUMMARY -->