### PR TITLE
docs: update previews state in different modes

### DIFF
--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -42,8 +42,6 @@ If a sandbox has an ongoing WebSocket/TCP connection, there is a 15-minute idle 
 
 When transitioning to standby mode, Blaxel automatically creates a snapshot of the entire state (including the complete file system in memory, preserving both files and running processes) and transitions the sandbox to standby mode within approximately 15 seconds.
 
-When a sandbox transitions to standby mode, none of its associated [preview URLs](/Sandboxes/Preview-url) are accessible.
-
 Reconnecting to the sandbox transitions it back to active mode. Any running processes are included in this snapshot and will be instantly restored when you reconnect to the sandbox.
 
 You are not charged for memory while a sandbox is in standby mode. However, you are charged for the storage of the snapshot and/or the volumes. [Learn more about pricing](https://blaxel.ai/pricing).

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -42,6 +42,8 @@ If a sandbox has an ongoing WebSocket/TCP connection, there is a 15-minute idle 
 
 When transitioning to standby mode, Blaxel automatically creates a snapshot of the entire state (including the complete file system in memory, preserving both files and running processes) and transitions the sandbox to standby mode within approximately 15 seconds.
 
+When a sandbox transitions to standby mode, none of its associated [preview URLs](/Sandboxes/Preview-url) are accessible.
+
 Reconnecting to the sandbox transitions it back to active mode. Any running processes are included in this snapshot and will be instantly restored when you reconnect to the sandbox.
 
 You are not charged for memory while a sandbox is in standby mode. However, you are charged for the storage of the snapshot and/or the volumes. [Learn more about pricing](https://blaxel.ai/pricing).

--- a/Sandboxes/Preview-url.mdx
+++ b/Sandboxes/Preview-url.mdx
@@ -309,3 +309,29 @@ preview = await sandbox.previews.create({
 <Note>
 When you register a custom domain, you also enable the use of wildcard subdomains for that domain. For example, if you register `mycompany.com`, you can configure preview URLs to use any `*.mycompany.com` subdomain.
 </Note>
+
+## Previews and sandbox state
+
+### Standby mode
+
+When a sandbox transitions to [standby mode](/Sandboxes/Overview#standby-mode), none of its associated preview URLs are accessible.
+
+### Sandbox deletion
+
+When a sandbox is deleted, whether manually or automatically due to a TTL or expiration policy, all of its associated preview URLs are automatically cleaned up as part of that deletion.
+
+If you need to remove a preview URL before a sandbox is deleted, you can do so explicitly using the SDKs.
+
+<CodeGroup>
+```typescript TypeScript
+const sandbox = await SandboxInstance.get("my-sandbox");
+
+await sandbox.previews.delete("app-preview");
+```
+
+```python Python
+sandbox = await SandboxInstance.get("my-sandbox")
+
+await sandbox.previews.delete("app-preview")
+```
+</CodeGroup>

--- a/Sandboxes/Preview-url.mdx
+++ b/Sandboxes/Preview-url.mdx
@@ -310,13 +310,7 @@ preview = await sandbox.previews.create({
 When you register a custom domain, you also enable the use of wildcard subdomains for that domain. For example, if you register `mycompany.com`, you can configure preview URLs to use any `*.mycompany.com` subdomain.
 </Note>
 
-## Previews and sandbox state
-
-### Standby mode
-
-When a sandbox transitions to [standby mode](/Sandboxes/Overview#standby-mode), none of its associated preview URLs are accessible.
-
-### Sandbox deletion
+## Delete a preview
 
 When a sandbox is deleted, whether manually or automatically due to a TTL or expiration policy, all of its associated preview URLs are automatically cleaned up as part of that deletion.
 


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new "Previews and sandbox state" section documenting preview URL behavior during standby mode and sandbox deletion, with SDK code examples for explicitly deleting preview URLs.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 845ddbb7e846f96803d7a910b8220e0543e022c8.</sup>
<!-- /MENDRAL_SUMMARY -->