### PR TITLE
docs: clarify usage of region parameter

### DIFF
--- a/Agents/Variables-and-secrets.mdx
+++ b/Agents/Variables-and-secrets.mdx
@@ -127,6 +127,8 @@ Authentication environment variables
 
 `BL_API_KEY` : can be set in your code to connect with the platform (locally or from a server not on Blaxel platform)
 
+ `BL_REGION` : default deployment [region](/Infrastructure/Regions)
+
 `BL_LOG_LEVEL` : Log level, default to info, can be set to debug,warn,error
 
 `BL_DEBUG_TELEMETRY`: Enable telemetry debug mode, will print each interaction with OpenTelemetry

--- a/Get-started.mdx
+++ b/Get-started.mdx
@@ -135,12 +135,12 @@ bl login
 
 <Accordion title="Learn more about authentication on Blaxel">
 
-The Blaxel SDK authenticates with your workspace using credentials from these sources, in priority order:
+The Blaxel SDK requires two environment variables to authenticate:
 
-1. when running on Blaxel, authentication is handled automatically
-2. variables in your `.env` file (`BL_WORKSPACE` and `BL_API_KEY`, or see [this page](/Agents/Variables-and-secrets) for other authentication options).
-3. environment variables from your machine
-4. configuration file created locally when you log in through [Blaxel CLI](../cli-reference/introduction) (or deploy on Blaxel)
+| Variable | Description |
+|---|---|
+| `BL_WORKSPACE` | Your Blaxel workspace name |
+| `BL_API_KEY` | Your Blaxel API key |
 
 You can create an API key from the [Blaxel console](https://app.blaxel.ai/profile/security). Your workspace name is visible in the URL when you log in to the console (e.g. `app.blaxel.ai/{workspace}`).
 

--- a/Get-started.mdx
+++ b/Get-started.mdx
@@ -138,7 +138,7 @@ bl login
 The Blaxel SDK authenticates with your workspace using credentials from these sources, in priority order:
 
 1. when running on Blaxel, authentication is handled automatically
-2. variables in your `.env` file (`BL_WORKSPACE` and `BL_API_KEY`, and optionally `BL_REGION`, or see [this page](/Agents/Variables-and-secrets) for other authentication options).
+2. variables in your `.env` file (`BL_WORKSPACE`, `BL_API_KEY`, and optionally `BL_REGION`, or see [this page](/Agents/Variables-and-secrets) for other authentication options).
 3. environment variables from your machine
 4. configuration file created locally when you log in through [Blaxel CLI](../cli-reference/introduction) (or deploy on Blaxel)
 

--- a/Get-started.mdx
+++ b/Get-started.mdx
@@ -135,12 +135,12 @@ bl login
 
 <Accordion title="Learn more about authentication on Blaxel">
 
-The Blaxel SDK requires two environment variables to authenticate:
+The Blaxel SDK authenticates with your workspace using credentials from these sources, in priority order:
 
-| Variable | Description |
-|---|---|
-| `BL_WORKSPACE` | Your Blaxel workspace name |
-| `BL_API_KEY` | Your Blaxel API key |
+1. when running on Blaxel, authentication is handled automatically
+2. variables in your `.env` file (`BL_WORKSPACE` and `BL_API_KEY`, and optionally `BL_REGION`, or see [this page](/Agents/Variables-and-secrets) for other authentication options).
+3. environment variables from your machine
+4. configuration file created locally when you log in through [Blaxel CLI](../cli-reference/introduction) (or deploy on Blaxel)
 
 You can create an API key from the [Blaxel console](https://app.blaxel.ai/profile/security). Your workspace name is visible in the URL when you log in to the console (e.g. `app.blaxel.ai/{workspace}`).
 

--- a/Get-started.mdx
+++ b/Get-started.mdx
@@ -138,7 +138,7 @@ bl login
 The Blaxel SDK authenticates with your workspace using credentials from these sources, in priority order:
 
 1. when running on Blaxel, authentication is handled automatically
-2. variables in your `.env` file (`BL_WORKSPACE`, `BL_API_KEY`, and optionally `BL_REGION`, or see [this page](/Agents/Variables-and-secrets) for other authentication options).
+2. variables in your `.env` file (`BL_WORKSPACE` and `BL_API_KEY`, or see [this page](/Agents/Variables-and-secrets) for other authentication options).
 3. environment variables from your machine
 4. configuration file created locally when you log in through [Blaxel CLI](../cli-reference/introduction) (or deploy on Blaxel)
 

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -251,7 +251,13 @@ You can expose specific non-reserved ports [**when creating a new sandbox**](Ove
 
 ### Regions
 
-Select the [region](../Infrastructure/Regions) where you want to deploy your sandbox. This parameter is required.
+Select the region where you want to deploy your sandbox. The `region` parameter is required, and can reference any of the [supported region codes](/Infrastructure/Regions).
+
+It is also possible to set a default region using the `BL_REGION` environment variable (e.g. in your `.env` file) to avoid repeating it in every SDK call.
+
+<Warning>
+  The `region` parameter is currently optional but will become mandatory in future versions of the Blaxel SDK. To ensure compatibility, it is highly recommended to always specify a deployment region, either using the `region` parameter in your SDK call or via the `BL_REGION` environment variable.
+</Warning>
 
 ### Labels
 

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -251,7 +251,7 @@ You can expose specific non-reserved ports [**when creating a new sandbox**](Ove
 
 ### Regions
 
-Select the region where you want to deploy your sandbox. The `region` parameter is required, and can reference any of the [supported region codes](/Infrastructure/Regions).
+Select the region where you want to deploy your sandbox. The `region` parameter is optional but recommended, and can reference any of the [supported region codes](/Infrastructure/Regions).
 
 It is also possible to set a default region using the `BL_REGION` environment variable (e.g. in your `.env` file) to avoid repeating it in every SDK call.
 


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR documents the `BL_REGION` environment variable: adds it to the Variables and Secrets reference page, and expands the Sandboxes region section with guidance on using `BL_REGION` as a default and a deprecation warning about the `region` parameter becoming mandatory in future SDK versions. The latest commit reverts an earlier auth section change.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit dfd0aeefefc093ff86d1277b417bb533f4d227ef.</sup>
<!-- /MENDRAL_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
