### PR TITLE
fix: update image id step

### DIFF
--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -839,11 +839,13 @@ python main.py
 
 ## Use a template
 
-Once your template is created, spawn new sandboxes instantly by using the image ID:
+Once a template is successfully pushed, you can spawn new sandboxes instantly by using its image ID.
+
+Use the following command to retrieve the image ID of the most recently pushed template:
 
 ```docker
 # Retrieve your IMAGE_ID
-bl get sandboxes mytemplate -ojson | jq -r '.[0].spec.runtime.image'
+bl get image sandbox/mytemplate -ojson | jq -r '.[0] | "sandbox/\(.metadata.name):\(.spec.tags | sort_by(.createdAt) | last | .name)"'
 ```
 
 <CodeGroup>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -3,6 +3,14 @@ title: 'Changelog'
 description: 'Chronological list of all platform updates, new features, deprecations, and infrastructure changes on Blaxel.'
 ---
 
+<Update label="2026-04-04">
+
+### Push images without deploying
+
+Added `bl push` command to build and push a container image to the Blaxel registry without creating a deployment.
+
+</Update>
+
 <Update label="2026-03-26">
 
 ### New proxy and network features


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Updates the "Use a template" section in Sandboxes/Templates.mdx to clarify the post-push workflow and fix the `bl` CLI command for retrieving a template's image ID. Also adds a changelog entry for the new `bl push` command.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4b42684ce9af5dca77ae3679038e152c07fc1a66.</sup>
<!-- /MENDRAL_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
