### PR TITLE
fix: clarify output of process.logs

### DIFF
--- a/Sandboxes/Processes.mdx
+++ b/Sandboxes/Processes.mdx
@@ -186,7 +186,7 @@ process = await sandbox.process.exec({
 
 </CodeGroup>
 
-When waiting for completion, the process execution object will contain a `.logs` object which [surfaces both *stdout* and *stderr*](/Sandboxes/Log-streaming). Also, notice the `timeout` parameter which allows to set a timeout duration on the process.
+When waiting for completion, the process execution object will contain a `.logs` field with the [combined `stdout` and `stderr` output as a string](/Sandboxes/Log-streaming). Also, notice the `timeout` parameter which allows to set a timeout duration on the process.
 
 <Warning>When using `waitForCompletion`, Blaxel enforces a **timeout limit of 60 seconds**. Don't set your timeout longer than this. For longer waiting periods, use the process-watching option described below.</Warning>
 


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Clarifies the description of the `.logs` field in the `waitForCompletion` section of the Processes documentation, changing "object which surfaces both stdout and stderr" to "field with the combined stdout and stderr output as a string".
> 
> <sup>Written by [Mendral](https://mendral.com) for commit fef54147ff09b9da81bf10d06b2241d3845ca757.</sup>
<!-- /MENDRAL_SUMMARY -->