### PR TITLE
docs: add list of sandbox templates

### DIFF
--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -231,7 +231,7 @@ Although less common, it is also possible to [create a sandbox by directly inter
 ### Images
 
 <Info>
-  The list of public images [can be found here](https://github.com/blaxel-ai/sandbox/tree/main/hub). To create a sandbox with one of those images, enter `blaxel/{NAME}:latest` (e.g. _blaxel/nextjs:latest_).
+  Blaxel provides [pre-built sandbox images](/Sandboxes/Templates#pre-built-templates) for common needs (e.g. `blaxel/nextjs:latest`, `blaxel/py-app:latest`).
 </Info>
 
 [Custom sandbox images](/Sandboxes/Templates) (or _templates_) enable you to create sandboxes with a consistent, customized set of tools, configurations, or entrypoint scripts.

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -230,11 +230,9 @@ Although less common, it is also possible to [create a sandbox by directly inter
 
 ### Images
 
-<Info>
-  Blaxel provides [pre-built sandbox images](/Sandboxes/Templates#pre-built-templates) for common needs (e.g. `blaxel/nextjs:latest`, `blaxel/py-app:latest`).
-</Info>
+Blaxel provides [pre-built sandbox images](/Sandboxes/Templates#pre-built-templates) for common needs (e.g. `blaxel/nextjs:latest`, `blaxel/py-app:latest`).
 
-[Custom sandbox images](/Sandboxes/Templates) (or _templates_) enable you to create sandboxes with a consistent, customized set of tools, configurations, or entrypoint scripts.
+It is also possible to build your own [custom images](/Sandboxes/Templates), which serve as _templates_ to create sandboxes with a consistent, customized set of tools, configurations, or entrypoint scripts.
 
 ### Memory and filesystem
 

--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -434,7 +434,7 @@ image = (
 
 </CodeGroup>
 
-###### Install system packages (apt, apk)
+##### Install system packages (apt, apk)
 
 <CodeGroup>
 
@@ -464,7 +464,7 @@ image = (
 
 </CodeGroup>
 
-###### Use other package managers
+##### Use other package managers
 
 <CodeGroup>
 
@@ -659,7 +659,7 @@ image = (
 
 </CodeGroup>
 
-##### Add local files
+###### Add local files
 
 Copy files and directories from your local machine into the image:
 

--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -659,7 +659,7 @@ image = (
 
 </CodeGroup>
 
-###### Add local files
+##### Add local files
 
 Copy files and directories from your local machine into the image:
 

--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -29,13 +29,45 @@ When you create a sandbox from a template, Blaxel provisions a new instance with
   You cannot directly use "library" container images (such as those hosted on Docker Hub and other registries) as sandbox templates. Instead, you must create one or more custom template images for your sandboxes using Dockerfiles and ensure that each template image includes Blaxel's sandbox API binary. This is necessary for sandbox functionality like process management and file operations.
 </Note>
 
-## Create a sandbox template
+## Pre-built templates
+
+Blaxel provides a library of pre-built templates for common needs.
+
+| Image | Description |
+|-------|-------------|
+| [`blaxel/base-image:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/base-image) | Minimal environment with Node.js 22 (Alpine) |
+| [`blaxel/py-app:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/py-app) | Python 3.12 development environment |
+| [`blaxel/ts-app:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/ts-app) | TypeScript development environment with Node.js 22 (slim) |
+| [`blaxel/node:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/node) | Node.js development environment with Node.js 23 (Alpine) |
+| [`blaxel/nextjs:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/nextjs) | Next.js development environment with Node.js 22 (Alpine) |
+| [`blaxel/vite:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/vite) | Vite + React + TS development environment with Node.js 22 (Alpine) |
+| [`blaxel/astro:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/astro) | Astro development environment with Node.js 22 (Alpine) |
+| [`blaxel/expo:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/expo) | React Native (Expo) development with Node.js 22 (Alpine) |
+| [`blaxel/chromium:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/chromium) | Headless Chromium environment with Chrome 124 (Alpine) |
+| [`blaxel/lightpanda:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/lightpanda) | Lightweight headless browser |
+| [`blaxel/playwright-chromium:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/playwright-chromium) | Playwright + Chromium browser automation environment with Node.js 20 |
+| [`blaxel/playwright-firefox:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/playwright-firefox) | Playwright + Firefox browser automation environment with Node.js 20 |
+| [`blaxel/docker-in-sandbox:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/docker-in-sandbox) | Docker-in-Docker environment |
+| [`blaxel/xfce-vnc:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/xfce-vnc) | XFCE desktop environment with VNC |
+| [`blaxel/cua-xfce:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/cua-xfce) XFCE desktop environment with CUA |
+| [`blaxel/jupyter-notebook:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/jupyter-notebook) | Jupyter Notebook with Python 3.12 |
+| [`blaxel/jupyter-server:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/jupyter-server) | Jupyter Server with Python 3.12 |
+| [`blaxel/benchmark:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/benchmark) | Sandbox benchmarking environment  |
+| [`blaxel/vibekit-claude:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/vibekit-claude) | VibeKit coding agent framework for Claude |
+| [`blaxel/vibekit-codex:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/vibekit-codex) | VibeKit coding agent framework for OpenAI Codex |
+| [`blaxel/vibekit-gemini:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/vibekit-gemini) | VibeKit coding agent framework for Google Gemini |
+| [`blaxel/vibekit-grok:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/vibekit-grok) | VibeKit coding agent framework for xAI Grok |
+| [`blaxel/vibekit-opencode:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/vibekit-opencode) | VibeKit coding agent framework for OpenCode |
+
+## Custom templates
+
+### Create a sandbox template
 
 You can create a sandbox template using the Blaxel CLI or REST API.
 
-### Blaxel CLI
+#### Blaxel CLI
 
-#### 1. Initialize a template
+##### 1. Initialize a template
 
 Start by creating a new sandbox template using the Blaxel CLI:
 
@@ -53,7 +85,7 @@ mytemplate/
 └── entrypoint.sh      # Initialization script
 ```
 
-#### 2. Customize the Dockerfile
+##### 2. Customize the Dockerfile
 
 The Dockerfile is the heart of your template. It defines what will be available in your sandbox environment.
 
@@ -81,7 +113,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 **Always include** the _sandbox-api_ binary from the Blaxel base image. This is required for sandbox functionality like process management and file operations.
 
-#### 3. Configure template settings
+##### 3. Configure template settings
 
 The `blaxel.toml` file defines your template’s runtime configuration:
 
@@ -114,7 +146,7 @@ PYTHON_ENV = "development"
   Currently, it is not possible to add or update environment variables for a sandbox after it is created. Ensure that any required environment variables are defined in your Dockerfile, your `blaxel.toml` file, or at sandbox creation time using the Blaxel SDKs.
 </Note>
 
-#### 4. Define initialization
+##### 4. Define initialization
 
 The `entrypoint.sh` script runs when a sandbox is created from your template:
 
@@ -149,7 +181,7 @@ fi
 wait
 ```
 
-#### 5. Build and test locally
+##### 5. Build and test locally
 
 Before creating the template on Blaxel, test it locally:
 
@@ -165,7 +197,7 @@ make run
 # Example: curl http://127.0.0.1:8080/process
 ```
 
-#### 6. Push the template
+##### 6. Push the template
 
 Once satisfied with your configuration, push the template to Blaxel:
 
@@ -195,7 +227,7 @@ This will:
   You can safely delete the sandbox afterwards, and keep using the template for new sandboxes.
 </Tip>
 
-### Blaxel SDK
+#### Blaxel SDK
 
 The Blaxel SDK includes a declarative image builder that lets you define custom sandbox images directly in your code using a fluent, chainable API. Instead of writing Dockerfiles manually, you describe your image step by step, and the SDK generates the Dockerfile, builds the image, and deploys it as a sandbox.
 
@@ -934,7 +966,7 @@ asyncio.run(main())
 | `baseImage` / `base_image` | Base image tag |
 
 
-### Blaxel API
+#### Blaxel API
 
 Although less common, it is also possible to create a sandbox template and sandbox by directly interacting with the Blaxel API.
 
@@ -943,7 +975,7 @@ Ensure that you have the following:
 - A [Blaxel API key](https://app.blaxel.ai/profile/security)
 - The workspace name, found at the bottom left corner of the [Blaxel Console](https://app.blaxel.ai/) or via `bl workspaces`
 
-#### 1. Create a ZIP archive
+##### 1. Create a ZIP archive
 
 Create a directory with the following project contents:
 
@@ -971,7 +1003,7 @@ Once the files are ready, create a ZIP archive containing the files:
 (cd mytemplate && zip -r ../mytemplate.zip .)
 ```
 
-#### 2. Create a sandbox resource
+##### 2. Create a sandbox resource
 
 Set your Blaxel API key and workspace as environment variables:
 
@@ -1015,7 +1047,7 @@ x-blaxel-upload-url: https://controlplane-prod-build-sources...
 
 Refer to the documentation on [sandbox configuration parameters](#understand-sandbox-configuration) for more information on the body of the POST request.
 
-#### 3. Upload ZIP archive
+##### 3. Upload ZIP archive
 
 Use an HTTP PUT request to upload the ZIP file to the upload URL. Replace the placeholder URL in the command below with the value of the `x-blaxel-upload-url` response header received earlier.
 
@@ -1028,7 +1060,7 @@ curl -X PUT "$UPLOAD_URL" \
 
 The upload is successful when you receive a `200 OK` status code.
 
-#### 4. Monitor deployment status
+##### 4. Monitor deployment status
 
 After uploading, poll the sandbox status endpoint to track the build and deployment progress.
 
@@ -1053,7 +1085,7 @@ Continue polling every 3-5 seconds until the status reaches `DEPLOYED` or `FAILE
 
 A first sandbox with that template is automatically created on Blaxel once deployment succeeds. You can safely delete the sandbox and keep using the template for new sandboxes.
 
-#### Example script
+##### Example script
 
 Here's a complete example script that performs all the steps above:
 
@@ -1576,7 +1608,7 @@ python main.py
 </CodeGroup>
 
 
-## Use a template
+### Use a custom template
 
 Once a template is successfully pushed, you can spawn new sandboxes instantly by using its image ID.
 
@@ -1584,7 +1616,7 @@ Use the following command to retrieve the image ID of the most recently pushed t
 
 ```docker
 # Retrieve your IMAGE_ID
-bl get image sandbox/mytemplate -ojson | jq -r '.[0] | "sandbox/\(.metadata.name):\(.spec.tags | sort_by(.createdAt) | last | .name)"'
+bl get image sandbox/mytemplate --latest
 ```
 
 <CodeGroup>
@@ -1617,9 +1649,9 @@ sandbox = await SandboxInstance.create({
 
 </CodeGroup>
 
-## Update a template
+### Update a custom template
 
-To update an existing template:
+To update an existing custom template:
 
 1. Modify your Dockerfile or configuration
 2. Rebuild locally to test changes

--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -434,7 +434,7 @@ image = (
 
 </CodeGroup>
 
-##### Install system packages (apt, apk)
+###### Install system packages (apt, apk)
 
 <CodeGroup>
 
@@ -464,7 +464,7 @@ image = (
 
 </CodeGroup>
 
-##### Use other package managers
+###### Use other package managers
 
 <CodeGroup>
 

--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -26,12 +26,12 @@ When you create a sandbox from a template, Blaxel provisions a new instance with
 4. **Instantiation**: New sandboxes can be spawned from this template in seconds.
 
 <Note>
-  You cannot directly use "library" container images (such as those hosted on Docker Hub and other registries) as sandbox templates. Instead, you must create one or more custom template images for your sandboxes using Dockerfiles and ensure that each template image includes Blaxel's sandbox API binary. This is necessary for sandbox functionality like process management and file operations.
+  You cannot directly use "library" container images (such as those hosted on Docker Hub and other registries) as sandbox templates. Instead, you must create one or more custom images for your sandboxes using Dockerfiles and ensure that each  image includes Blaxel's sandbox API binary. This is necessary for sandbox functionality like process management and file operations.
 </Note>
 
 ## Pre-built templates
 
-Blaxel provides a library of pre-built templates for common needs.
+Blaxel provides a library of pre-built container images that serve as sandbox templates for common needs.
 
 | Image | Description |
 |-------|-------------|

--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -61,9 +61,11 @@ Blaxel provides a library of pre-built templates for common needs.
 
 ## Custom templates
 
+You can also customize a template for specific needs.
+
 ### Create a sandbox template
 
-You can create a sandbox template using the Blaxel CLI or REST API.
+You can create a customized sandbox template using the Blaxel CLI or REST API.
 
 #### Blaxel CLI
 

--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -280,7 +280,7 @@ The three steps to use the image builder are:
 
 The SDK automatically injects the Blaxel sandbox API binary and sets a default entrypoint (if you haven't specified one), so your image is ready to use as a sandbox without manual configuration.
 
-#### Select a base image
+##### Select a base image
 
 Start by selecting a base image from any Docker registry:
 
@@ -300,7 +300,7 @@ image = ImageInstance.from_registry("ubuntu:22.04")
 
 </CodeGroup>
 
-#### Execute build commands
+##### Execute build commands
 
 Execute shell commands during the image build:
 
@@ -324,11 +324,11 @@ image = (
 
 </CodeGroup>
 
-#### Use package managers
+##### Use package managers
 
 The SDK provides convenience methods for common package managers. These generate optimized `RUN` commands with sensible defaults (e.g., cache cleanup for apt).
 
-##### Python (pip)
+###### Python (pip)
 
 <CodeGroup>
 
@@ -367,7 +367,7 @@ image = (
 
 </CodeGroup>
 
-##### Python (uv)
+###### Python (uv)
 
 <CodeGroup>
 
@@ -387,7 +387,7 @@ image = (
 
 </CodeGroup>
 
-##### Node.js (npm, yarn, pnpm, bun)
+###### Node.js (npm, yarn, pnpm, bun)
 
 <CodeGroup>
 
@@ -434,7 +434,7 @@ image = (
 
 </CodeGroup>
 
-##### Install system packages (apt, apk)
+###### Install system packages (apt, apk)
 
 <CodeGroup>
 
@@ -464,7 +464,7 @@ image = (
 
 </CodeGroup>
 
-##### Use other package managers
+###### Use other package managers
 
 <CodeGroup>
 
@@ -524,11 +524,11 @@ image = (
 
 </CodeGroup>
 
-#### Add Dockerfile instructions
+##### Add Dockerfile instructions
 
 All standard Dockerfile instructions are available as methods.
 
-##### Specify the working directory
+###### Specify the working directory
 
 <CodeGroup>
 
@@ -543,7 +543,7 @@ image = ImageInstance.from_registry("node:20").workdir("/app")
 
 </CodeGroup>
 
-##### Define environment variables
+###### Define environment variables
 
 <CodeGroup>
 
@@ -564,7 +564,7 @@ image = (
 
 </CodeGroup>
 
-##### Copy files
+###### Copy files
 
 <CodeGroup>
 
@@ -586,7 +586,7 @@ image = (
 
 </CodeGroup>
 
-##### Expose ports
+###### Expose ports
 
 <CodeGroup>
 
@@ -601,7 +601,7 @@ image = ImageInstance.from_registry("node:20").expose(3000, 8080)
 
 </CodeGroup>
 
-##### Set an entrypoint
+###### Set an entrypoint
 
 <CodeGroup>
 
@@ -619,7 +619,7 @@ image = (
 
 </CodeGroup>
 
-##### Add users
+###### Add users
 
 <CodeGroup>
 
@@ -639,7 +639,7 @@ image = (
 
 </CodeGroup>
 
-##### Add labels and build arguments
+###### Add labels and build arguments
 
 <CodeGroup>
 
@@ -659,7 +659,7 @@ image = (
 
 </CodeGroup>
 
-#### Add local files
+##### Add local files
 
 Copy files and directories from your local machine into the image:
 
@@ -685,9 +685,9 @@ image = (
 
 Local files are resolved to absolute paths, included in the build context, and `COPY`-ed into the image. You can optionally provide a `contextName` (TypeScript) / `context_name` (Python) parameter to control the filename in the build context.
 
-#### Build and deploy
+##### Build and deploy
 
-##### Basic build
+###### Basic build
 
 <CodeGroup>
 
@@ -703,7 +703,7 @@ sandbox = await image.build(name="my-sandbox")
 
 </CodeGroup>
 
-##### Build with all options
+###### Build with all options
 
 <CodeGroup>
 
@@ -738,7 +738,7 @@ The `build()` method automatically:
 - Uploads and deploys the image as a sandbox
 - Polls until the sandbox reaches `DEPLOYED` or `FAILED` status
 
-##### Inspect the generated Dockerfile
+###### Inspect the generated Dockerfile
 
 You can preview the Dockerfile without building:
 
@@ -774,7 +774,7 @@ print(image.dockerfile)
 
 </CodeGroup>
 
-##### Write to disk
+###### Write to disk
 
 You can also write the image to a folder for manual inspection or use with `bl deploy`:
 
@@ -798,7 +798,7 @@ temp_dir = image.write_temp()
 
 </CodeGroup>
 
-#### Understand immutability and branching
+##### Understand immutability and branching
 
 Each method returns a new `ImageInstance`, leaving the original unchanged. This lets you create base images and branch from them:
 
@@ -854,7 +854,7 @@ web_sandbox = await web_image.build(name="web-sandbox", memory=4096)
 
 </CodeGroup>
 
-#### Example script
+##### Example script
 
 A complete example building a Node.js / Python development sandbox:
 
@@ -922,9 +922,9 @@ asyncio.run(main())
 
 </CodeGroup>
 
-#### API reference
+##### API reference
 
-##### Methods
+###### Methods
 
 | Method | Description |
 |--------|-------------|
@@ -954,7 +954,7 @@ asyncio.run(main())
 | `write` | Write image to a folder |
 | `writeTemp` / `write_temp` | Write image to a temporary folder |
 
-##### Properties
+###### Properties
 
 | Property | Description |
 |----------|-------------|

--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -53,11 +53,6 @@ Blaxel provides a library of pre-built templates for common needs.
 | [`blaxel/jupyter-notebook:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/jupyter-notebook) | Jupyter Notebook with Python 3.12 |
 | [`blaxel/jupyter-server:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/jupyter-server) | Jupyter Server with Python 3.12 |
 | [`blaxel/benchmark:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/benchmark) | Sandbox benchmarking environment  |
-| [`blaxel/vibekit-claude:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/vibekit-claude) | VibeKit coding agent framework for Claude |
-| [`blaxel/vibekit-codex:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/vibekit-codex) | VibeKit coding agent framework for OpenAI Codex |
-| [`blaxel/vibekit-gemini:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/vibekit-gemini) | VibeKit coding agent framework for Google Gemini |
-| [`blaxel/vibekit-grok:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/vibekit-grok) | VibeKit coding agent framework for xAI Grok |
-| [`blaxel/vibekit-opencode:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/vibekit-opencode) | VibeKit coding agent framework for OpenCode |
 
 ## Custom templates
 

--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -49,7 +49,7 @@ Blaxel provides a library of pre-built templates for common needs.
 | [`blaxel/playwright-firefox:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/playwright-firefox) | Playwright + Firefox browser automation environment with Node.js 20 |
 | [`blaxel/docker-in-sandbox:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/docker-in-sandbox) | Docker-in-Docker environment |
 | [`blaxel/xfce-vnc:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/xfce-vnc) | XFCE desktop environment with VNC |
-| [`blaxel/cua-xfce:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/cua-xfce) XFCE desktop environment with CUA |
+| [`blaxel/cua-xfce:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/cua-xfce) | XFCE desktop environment with CUA |
 | [`blaxel/jupyter-notebook:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/jupyter-notebook) | Jupyter Notebook with Python 3.12 |
 | [`blaxel/jupyter-server:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/jupyter-server) | Jupyter Server with Python 3.12 |
 | [`blaxel/benchmark:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/benchmark) | Sandbox benchmarking environment  |


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a "Pre-built templates" section to Templates.mdx listing official Blaxel sandbox images with GitHub source links, reorganizes existing custom template content under a "Custom templates" heading with adjusted heading levels, and updates Overview.mdx to link to the new pre-built templates section.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit fb11d7d7e435cec8f2cdcd1c116ec059a69bb1fe.</sup>
<!-- /MENDRAL_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
