### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -2300,6 +2300,13 @@ components:
           $ref: '#/components/schemas/Metadata'
         spec:
           $ref: '#/components/schemas/SandboxSpec'
+        state:
+          type: string
+          description: Current state of the sandbox (read-only, managed by the system)
+          enum:
+          - RUNNING
+          - STANDBY
+          readOnly: true
         status:
           $ref: '#/components/schemas/Status'
       required:


### PR DESCRIPTION
Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a read-only `state` field to the `Sandbox` schema in the OpenAPI spec, exposing two possible values (`RUNNING`, `STANDBY`) to document the sandbox lifecycle state managed by the system.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e0e8a2066e029993d6cc8a22aa86f9aa40db9c68.</sup>
<!-- /MENDRAL_SUMMARY -->