### PR TITLE
docs: update Ports SDK section with new fetch method

### DIFF
--- a/Sandboxes/Ports.mdx
+++ b/Sandboxes/Ports.mdx
@@ -85,41 +85,39 @@ Generally speaking:
 
 ### Via SDK
 
-This option requires your request to be [authenticated](../Security/Access-tokens).
+The SDK provides a built-in `fetch` method that handles authentication and proxies requests through the sandbox's `/port/{port}` endpoint.
 
 <CodeGroup>
 
 ```typescript TypeScript
 import { SandboxInstance } from "@blaxel/core";
 
-// Connect to existing sandbox
-const sandbox = await SandboxInstance.get("my-sandbox")
+const sandbox = await SandboxInstance.get("my-sandbox");
 
-// Assume port 3000
-const portNumber = 3000;
+// Fetch a resource on port 3000
+const response = await sandbox.fetch(3000);
+console.log(await response.text());
 
-// Get URL for port access
-const url = `${sandbox.metadata.url}/port/${portNumber}`
-
-// Use the URL with authenticated requests
-// Example: const response = await fetch(url, { headers: { 'Authorization': 'Bearer YOUR_TOKEN' } })
+// Fetch with a specific path
+const apiResponse = await sandbox.fetch(3000, "/api/health");
+console.log(await apiResponse.json());
 ```
 
 ```python Python
 from blaxel.core import SandboxInstance
-import requests
 
-# Connect to existing sandbox
 sandbox = await SandboxInstance.get("my-sandbox")
 
-# Assume port 3000
-port_number = 3000;
+# Fetch a resource on port 3000
+response = await sandbox.fetch(3000)
+print(response.text)
 
-# Get URL for port access
-url = f"{sandbox.metadata.url}/port/{port_number}"
+# Fetch with a specific path
+api_response = await sandbox.fetch(3000, "/api/health")
+print(api_response.json())
 
-# Use the URL with authenticated requests
-# Example: response = requests.get(url, headers={ "Authorization": f"Bearer YOUR_TOKEN" })
+# Fetch with a custom HTTP method
+post_response = await sandbox.fetch(3000, "/api/data", method="POST", json={"key": "value"})
 ```
 </CodeGroup>
 

--- a/Sandboxes/Ports.mdx
+++ b/Sandboxes/Ports.mdx
@@ -125,6 +125,7 @@ print(api_response.json())
 
 # Fetch with a custom HTTP method
 post_response = await sandbox.fetch(3000, "/api/data", method="POST", json={"key": "value"})
+print(post_response.json())
 ```
 
 </CodeGroup>

--- a/Sandboxes/Ports.mdx
+++ b/Sandboxes/Ports.mdx
@@ -85,6 +85,13 @@ Generally speaking:
 
 ### Via SDK
 
+<Tabs>
+<Tab title="sandbox.fetch() (recommended)">
+
+<Note>
+  Available in `@blaxel/core` >= 0.2.79 (Node.js) and `blaxel` >= 0.2.49 (Python).
+</Note>
+
 The SDK provides a built-in `fetch` method that handles authentication and proxies requests through the sandbox's `/port/{port}` endpoint.
 
 <CodeGroup>
@@ -119,7 +126,49 @@ print(api_response.json())
 # Fetch with a custom HTTP method
 post_response = await sandbox.fetch(3000, "/api/data", method="POST", json={"key": "value"})
 ```
+
 </CodeGroup>
+
+</Tab>
+<Tab title="Manual URL (older SDKs)">
+
+For older SDK versions, you can construct the port URL manually. This requires your request to be [authenticated](../Security/Access-tokens).
+
+<CodeGroup>
+
+```typescript TypeScript
+import { SandboxInstance } from "@blaxel/core";
+
+// Connect to existing sandbox
+const sandbox = await SandboxInstance.get("my-sandbox")
+
+// Get URL for port access
+const url = `${sandbox.metadata.url}/port/3000`
+
+// Use the URL with authenticated requests
+const response = await fetch(url, {
+  headers: { 'Authorization': 'Bearer YOUR_TOKEN' }
+})
+```
+
+```python Python
+from blaxel.core import SandboxInstance
+import requests
+
+# Connect to existing sandbox
+sandbox = await SandboxInstance.get("my-sandbox")
+
+# Get URL for port access
+url = f"{sandbox.metadata.url}/port/3000"
+
+# Use the URL with authenticated requests
+response = requests.get(url, headers={ "Authorization": f"Bearer YOUR_TOKEN" })
+```
+
+</CodeGroup>
+
+</Tab>
+</Tabs>
 
 <Card title="Create preview URLs" icon="eye" href="/Sandboxes/Preview-url">
 Expose applications running within the sandbox via a direct preview URL.


### PR DESCRIPTION
## Summary
- Replaces manual URL construction in the "Via SDK" section with the new `sandbox.fetch()` method
- Shows examples for TypeScript and Python including basic fetch, path-based fetch, and custom HTTP methods
- Companion to SDK PRs: blaxel-ai/sdk-python#129, stainless-sdks/blaxel-go#5

## Test plan
- [ ] Verify Mintlify renders the updated CodeGroup correctly
- [ ] Verify code examples are syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Restructures the "Via SDK" section into two tabs: a recommended `sandbox.fetch()` tab with TypeScript and Python examples (including version requirements), and a legacy "Manual URL" tab for older SDK versions with working code instead of commented-out snippets.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a0803ae4af85d2278c50d2011b5d6434ec810fd4.</sup>
<!-- /MENDRAL_SUMMARY -->