### PR TITLE
chore: auto-update cli docs from upstream

### DIFF
--- a/cli-reference/commands/bl.md
+++ b/cli-reference/commands/bl.md
@@ -4,7 +4,7 @@ slug: bl
 ---
 ## bl
 
-Blaxel CLI is a command line tool to interact with Blaxel APIs.
+Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 
 ### Options
 
@@ -22,19 +22,19 @@ Blaxel CLI is a command line tool to interact with Blaxel APIs.
 * [bl apply](/cli-reference/commands/bl_apply)	 - Apply a configuration to a resource by file
 * [bl chat](/cli-reference/commands/bl_chat)	 - Chat with an agent
 * [bl completion](/cli-reference/commands/bl_completion)	 - Generate shell completion scripts
-* [bl connect](/cli-reference/commands/bl_connect)	 - Connect into your sandbox resources
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
-* [bl deploy](/cli-reference/commands/bl_deploy)	 - Deploy on blaxel
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl connect](/cli-reference/commands/bl_connect)	 - Open an interactive terminal session to a sandbox
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
+* [bl deploy](/cli-reference/commands/bl_deploy)	 - Build, push, and deploy your project to Blaxel
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 * [bl login](/cli-reference/commands/bl_login)	 - Login to Blaxel
 * [bl logout](/cli-reference/commands/bl_logout)	 - Logout from Blaxel
-* [bl logs](/cli-reference/commands/bl_logs)	 - View logs for a resource
-* [bl new](/cli-reference/commands/bl_new)	 - Create a new blaxel resource (agent, mcp, sandbox, job, volume-template)
-* [bl push](/cli-reference/commands/bl_push)	 - Build and push an image to the Blaxel registry
-* [bl run](/cli-reference/commands/bl_run)	 - Run a resource on blaxel
-* [bl serve](/cli-reference/commands/bl_serve)	 - Serve a blaxel project
+* [bl logs](/cli-reference/commands/bl_logs)	 - View and stream logs for agents, jobs, sandboxes, and functions
+* [bl new](/cli-reference/commands/bl_new)	 - Scaffold a new project from a template (agent, mcp, sandbox, job, volume-template)
+* [bl push](/cli-reference/commands/bl_push)	 - Build and push a container image to the Blaxel registry
+* [bl run](/cli-reference/commands/bl_run)	 - Execute a resource (agent, model, job, function, sandbox)
+* [bl serve](/cli-reference/commands/bl_serve)	 - Start a local development server for your project
 * [bl token](/cli-reference/commands/bl_token)	 - Retrieve authentication token for a workspace
 * [bl upgrade](/cli-reference/commands/bl_upgrade)	 - Upgrade the Blaxel CLI to the latest version
 * [bl version](/cli-reference/commands/bl_version)	 - Print the version number
-* [bl workspaces](/cli-reference/commands/bl_workspaces)	 - List all workspaces with the current workspace highlighted, set optionally a new current workspace
+* [bl workspaces](/cli-reference/commands/bl_workspaces)	 - List workspaces or switch the current workspace
 

--- a/cli-reference/commands/bl_apply.md
+++ b/cli-reference/commands/bl_apply.md
@@ -128,5 +128,5 @@ bl apply [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_chat.md
+++ b/cli-reference/commands/bl_chat.md
@@ -76,5 +76,5 @@ bl chat [agent-name] [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_completion.md
+++ b/cli-reference/commands/bl_completion.md
@@ -65,5 +65,5 @@ bl completion [bash|zsh|fish|powershell]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_connect.md
+++ b/cli-reference/commands/bl_connect.md
@@ -4,11 +4,11 @@ slug: bl_connect
 ---
 ## bl connect
 
-Connect into your sandbox resources
+Open an interactive terminal session to a sandbox
 
 ### Synopsis
 
-Connect into your sandbox resources with interactive interfaces
+Open an interactive terminal session to a sandbox
 
 ### Options
 
@@ -28,6 +28,6 @@ Connect into your sandbox resources with interactive interfaces
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 * [bl connect sandbox](/cli-reference/commands/bl_connect_sandbox)	 - Connect to a sandbox environment
 

--- a/cli-reference/commands/bl_connect_sandbox.md
+++ b/cli-reference/commands/bl_connect_sandbox.md
@@ -42,5 +42,5 @@ bl connect sandbox [sandbox-name] [flags]
 
 ### SEE ALSO
 
-* [bl connect](/cli-reference/commands/bl_connect)	 - Connect into your sandbox resources
+* [bl connect](/cli-reference/commands/bl_connect)	 - Open an interactive terminal session to a sandbox
 

--- a/cli-reference/commands/bl_delete.md
+++ b/cli-reference/commands/bl_delete.md
@@ -4,7 +4,7 @@ slug: bl_delete
 ---
 ## bl delete
 
-Delete a resource
+Delete resources from your workspace
 
 ### Synopsis
 
@@ -103,18 +103,18 @@ bl delete [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
-* [bl delete agent](/cli-reference/commands/bl_delete_agent)	 - Delete agent
-* [bl delete drive](/cli-reference/commands/bl_delete_drive)	 - Delete drive
-* [bl delete function](/cli-reference/commands/bl_delete_function)	 - Delete function
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
+* [bl delete agent](/cli-reference/commands/bl_delete_agent)	 - Delete one or more agents
+* [bl delete drive](/cli-reference/commands/bl_delete_drive)	 - Delete one or more drives
+* [bl delete function](/cli-reference/commands/bl_delete_function)	 - Delete one or more functions
 * [bl delete image](/cli-reference/commands/bl_delete_image)	 - Delete images or image tags
-* [bl delete integrationconnection](/cli-reference/commands/bl_delete_integrationconnection)	 - Delete integrationconnection
-* [bl delete job](/cli-reference/commands/bl_delete_job)	 - Delete job
-* [bl delete model](/cli-reference/commands/bl_delete_model)	 - Delete model
-* [bl delete policy](/cli-reference/commands/bl_delete_policy)	 - Delete policy
-* [bl delete preview](/cli-reference/commands/bl_delete_preview)	 - Delete preview
-* [bl delete previewtoken](/cli-reference/commands/bl_delete_previewtoken)	 - Delete previewtoken
-* [bl delete sandbox](/cli-reference/commands/bl_delete_sandbox)	 - Delete sandbox
-* [bl delete volume](/cli-reference/commands/bl_delete_volume)	 - Delete volume
-* [bl delete volumetemplate](/cli-reference/commands/bl_delete_volumetemplate)	 - Delete volumetemplate
+* [bl delete integrationconnection](/cli-reference/commands/bl_delete_integrationconnection)	 - Delete one or more integrationconnections
+* [bl delete job](/cli-reference/commands/bl_delete_job)	 - Delete one or more jobs
+* [bl delete model](/cli-reference/commands/bl_delete_model)	 - Delete one or more models
+* [bl delete policy](/cli-reference/commands/bl_delete_policy)	 - Delete one or more policies
+* [bl delete preview](/cli-reference/commands/bl_delete_preview)	 - Delete one or more previews
+* [bl delete previewtoken](/cli-reference/commands/bl_delete_previewtoken)	 - Delete one or more previewtokens
+* [bl delete sandbox](/cli-reference/commands/bl_delete_sandbox)	 - Delete one or more sandboxes
+* [bl delete volume](/cli-reference/commands/bl_delete_volume)	 - Delete one or more volumes
+* [bl delete volumetemplate](/cli-reference/commands/bl_delete_volumetemplate)	 - Delete one or more volumetemplates
 

--- a/cli-reference/commands/bl_delete_agent.md
+++ b/cli-reference/commands/bl_delete_agent.md
@@ -4,7 +4,7 @@ slug: bl_delete_agent
 ---
 ## bl delete agent
 
-Delete agent
+Delete one or more agents
 
 ```
 bl delete agent name [name...] [flags]
@@ -28,5 +28,5 @@ bl delete agent name [name...] [flags]
 
 ### SEE ALSO
 
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
 

--- a/cli-reference/commands/bl_delete_drive.md
+++ b/cli-reference/commands/bl_delete_drive.md
@@ -4,7 +4,7 @@ slug: bl_delete_drive
 ---
 ## bl delete drive
 
-Delete drive
+Delete one or more drives
 
 ```
 bl delete drive name [name...] [flags]
@@ -28,5 +28,5 @@ bl delete drive name [name...] [flags]
 
 ### SEE ALSO
 
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
 

--- a/cli-reference/commands/bl_delete_function.md
+++ b/cli-reference/commands/bl_delete_function.md
@@ -4,7 +4,7 @@ slug: bl_delete_function
 ---
 ## bl delete function
 
-Delete function
+Delete one or more functions
 
 ```
 bl delete function name [name...] [flags]
@@ -28,5 +28,5 @@ bl delete function name [name...] [flags]
 
 ### SEE ALSO
 
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
 

--- a/cli-reference/commands/bl_delete_image.md
+++ b/cli-reference/commands/bl_delete_image.md
@@ -56,5 +56,5 @@ bl delete image [resourceType/]imageName[:tag] ... [flags]
 
 ### SEE ALSO
 
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
 

--- a/cli-reference/commands/bl_delete_integrationconnection.md
+++ b/cli-reference/commands/bl_delete_integrationconnection.md
@@ -4,7 +4,7 @@ slug: bl_delete_integrationconnection
 ---
 ## bl delete integrationconnection
 
-Delete integrationconnection
+Delete one or more integrationconnections
 
 ```
 bl delete integrationconnection name [name...] [flags]
@@ -28,5 +28,5 @@ bl delete integrationconnection name [name...] [flags]
 
 ### SEE ALSO
 
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
 

--- a/cli-reference/commands/bl_delete_job.md
+++ b/cli-reference/commands/bl_delete_job.md
@@ -4,7 +4,7 @@ slug: bl_delete_job
 ---
 ## bl delete job
 
-Delete job
+Delete one or more jobs
 
 ```
 bl delete job name [name...] [flags]
@@ -28,5 +28,5 @@ bl delete job name [name...] [flags]
 
 ### SEE ALSO
 
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
 

--- a/cli-reference/commands/bl_delete_model.md
+++ b/cli-reference/commands/bl_delete_model.md
@@ -4,7 +4,7 @@ slug: bl_delete_model
 ---
 ## bl delete model
 
-Delete model
+Delete one or more models
 
 ```
 bl delete model name [name...] [flags]
@@ -28,5 +28,5 @@ bl delete model name [name...] [flags]
 
 ### SEE ALSO
 
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
 

--- a/cli-reference/commands/bl_delete_policy.md
+++ b/cli-reference/commands/bl_delete_policy.md
@@ -4,7 +4,7 @@ slug: bl_delete_policy
 ---
 ## bl delete policy
 
-Delete policy
+Delete one or more policies
 
 ```
 bl delete policy name [name...] [flags]
@@ -28,5 +28,5 @@ bl delete policy name [name...] [flags]
 
 ### SEE ALSO
 
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
 

--- a/cli-reference/commands/bl_delete_preview.md
+++ b/cli-reference/commands/bl_delete_preview.md
@@ -4,7 +4,7 @@ slug: bl_delete_preview
 ---
 ## bl delete preview
 
-Delete preview
+Delete one or more previews
 
 ```
 bl delete preview name [name...] [flags]
@@ -28,5 +28,5 @@ bl delete preview name [name...] [flags]
 
 ### SEE ALSO
 
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
 

--- a/cli-reference/commands/bl_delete_previewtoken.md
+++ b/cli-reference/commands/bl_delete_previewtoken.md
@@ -4,7 +4,7 @@ slug: bl_delete_previewtoken
 ---
 ## bl delete previewtoken
 
-Delete previewtoken
+Delete one or more previewtokens
 
 ```
 bl delete previewtoken name [name...] [flags]
@@ -28,5 +28,5 @@ bl delete previewtoken name [name...] [flags]
 
 ### SEE ALSO
 
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
 

--- a/cli-reference/commands/bl_delete_sandbox.md
+++ b/cli-reference/commands/bl_delete_sandbox.md
@@ -4,7 +4,7 @@ slug: bl_delete_sandbox
 ---
 ## bl delete sandbox
 
-Delete sandbox
+Delete one or more sandboxes
 
 ```
 bl delete sandbox name [name...] [flags]
@@ -28,5 +28,5 @@ bl delete sandbox name [name...] [flags]
 
 ### SEE ALSO
 
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
 

--- a/cli-reference/commands/bl_delete_volume.md
+++ b/cli-reference/commands/bl_delete_volume.md
@@ -4,7 +4,7 @@ slug: bl_delete_volume
 ---
 ## bl delete volume
 
-Delete volume
+Delete one or more volumes
 
 ```
 bl delete volume name [name...] [flags]
@@ -28,5 +28,5 @@ bl delete volume name [name...] [flags]
 
 ### SEE ALSO
 
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
 

--- a/cli-reference/commands/bl_delete_volumetemplate.md
+++ b/cli-reference/commands/bl_delete_volumetemplate.md
@@ -4,7 +4,7 @@ slug: bl_delete_volumetemplate
 ---
 ## bl delete volumetemplate
 
-Delete volumetemplate
+Delete one or more volumetemplates
 
 ```
 bl delete volumetemplate name [name...] [flags]
@@ -28,5 +28,5 @@ bl delete volumetemplate name [name...] [flags]
 
 ### SEE ALSO
 
-* [bl delete](/cli-reference/commands/bl_delete)	 - Delete a resource
+* [bl delete](/cli-reference/commands/bl_delete)	 - Delete resources from your workspace
 

--- a/cli-reference/commands/bl_deploy.md
+++ b/cli-reference/commands/bl_deploy.md
@@ -4,7 +4,7 @@ slug: bl_deploy
 ---
 ## bl deploy
 
-Deploy on blaxel
+Build, push, and deploy your project to Blaxel
 
 ### Synopsis
 
@@ -100,5 +100,5 @@ bl deploy [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_get.md
+++ b/cli-reference/commands/bl_get.md
@@ -4,7 +4,7 @@ slug: bl_get
 ---
 ## bl get
 
-Get a resource
+List or retrieve Blaxel resources in your workspace
 
 ### Synopsis
 
@@ -129,18 +129,18 @@ The command can list all resources of a type or get details for a specific one.
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
-* [bl get agents](/cli-reference/commands/bl_get_agents)	 - Get a Agent
-* [bl get drives](/cli-reference/commands/bl_get_drives)	 - Get a Drive
-* [bl get functions](/cli-reference/commands/bl_get_functions)	 - Get a Function
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
+* [bl get agents](/cli-reference/commands/bl_get_agents)	 - List all agents or get details of a specific one
+* [bl get drives](/cli-reference/commands/bl_get_drives)	 - List all drives or get details of a specific one
+* [bl get functions](/cli-reference/commands/bl_get_functions)	 - List all functions or get details of a specific one
 * [bl get image](/cli-reference/commands/bl_get_image)	 - Get image information
-* [bl get integrationconnections](/cli-reference/commands/bl_get_integrationconnections)	 - Get a IntegrationConnection
-* [bl get jobs](/cli-reference/commands/bl_get_jobs)	 - Get a Job
-* [bl get models](/cli-reference/commands/bl_get_models)	 - Get a Model
-* [bl get policies](/cli-reference/commands/bl_get_policies)	 - Get a Policy
-* [bl get previews](/cli-reference/commands/bl_get_previews)	 - Get a Preview
-* [bl get previewtokens](/cli-reference/commands/bl_get_previewtokens)	 - Get a PreviewToken
-* [bl get sandboxes](/cli-reference/commands/bl_get_sandboxes)	 - Get a Sandbox
-* [bl get volumes](/cli-reference/commands/bl_get_volumes)	 - Get a Volume
-* [bl get volumetemplates](/cli-reference/commands/bl_get_volumetemplates)	 - Get a VolumeTemplate
+* [bl get integrationconnections](/cli-reference/commands/bl_get_integrationconnections)	 - List all integrationconnections or get details of a specific one
+* [bl get jobs](/cli-reference/commands/bl_get_jobs)	 - List all jobs or get details of a specific one
+* [bl get models](/cli-reference/commands/bl_get_models)	 - List all models or get details of a specific one
+* [bl get policies](/cli-reference/commands/bl_get_policies)	 - List all policies or get details of a specific one
+* [bl get previews](/cli-reference/commands/bl_get_previews)	 - List all previews or get details of a specific one
+* [bl get previewtokens](/cli-reference/commands/bl_get_previewtokens)	 - List all previewtokens or get details of a specific one
+* [bl get sandboxes](/cli-reference/commands/bl_get_sandboxes)	 - List all sandboxes or get details of a specific one
+* [bl get volumes](/cli-reference/commands/bl_get_volumes)	 - List all volumes or get details of a specific one
+* [bl get volumetemplates](/cli-reference/commands/bl_get_volumetemplates)	 - List all volumetemplates or get details of a specific one
 

--- a/cli-reference/commands/bl_get_agents.md
+++ b/cli-reference/commands/bl_get_agents.md
@@ -4,7 +4,7 @@ slug: bl_get_agents
 ---
 ## bl get agents
 
-Get a Agent
+List all agents or get details of a specific one
 
 ```
 bl get agents [flags]
@@ -29,5 +29,5 @@ bl get agents [flags]
 
 ### SEE ALSO
 
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 

--- a/cli-reference/commands/bl_get_drives.md
+++ b/cli-reference/commands/bl_get_drives.md
@@ -4,7 +4,7 @@ slug: bl_get_drives
 ---
 ## bl get drives
 
-Get a Drive
+List all drives or get details of a specific one
 
 ```
 bl get drives [flags]
@@ -29,5 +29,5 @@ bl get drives [flags]
 
 ### SEE ALSO
 
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 

--- a/cli-reference/commands/bl_get_functions.md
+++ b/cli-reference/commands/bl_get_functions.md
@@ -4,7 +4,7 @@ slug: bl_get_functions
 ---
 ## bl get functions
 
-Get a Function
+List all functions or get details of a specific one
 
 ```
 bl get functions [flags]
@@ -29,5 +29,5 @@ bl get functions [flags]
 
 ### SEE ALSO
 
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 

--- a/cli-reference/commands/bl_get_image.md
+++ b/cli-reference/commands/bl_get_image.md
@@ -69,5 +69,5 @@ bl get image [resourceType/imageName[:tag]] [flags]
 
 ### SEE ALSO
 
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 

--- a/cli-reference/commands/bl_get_integrationconnections.md
+++ b/cli-reference/commands/bl_get_integrationconnections.md
@@ -4,7 +4,7 @@ slug: bl_get_integrationconnections
 ---
 ## bl get integrationconnections
 
-Get a IntegrationConnection
+List all integrationconnections or get details of a specific one
 
 ```
 bl get integrationconnections [flags]
@@ -29,5 +29,5 @@ bl get integrationconnections [flags]
 
 ### SEE ALSO
 
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 

--- a/cli-reference/commands/bl_get_jobs.md
+++ b/cli-reference/commands/bl_get_jobs.md
@@ -4,7 +4,7 @@ slug: bl_get_jobs
 ---
 ## bl get jobs
 
-Get a Job
+List all jobs or get details of a specific one
 
 ```
 bl get jobs [flags]
@@ -29,5 +29,5 @@ bl get jobs [flags]
 
 ### SEE ALSO
 
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 

--- a/cli-reference/commands/bl_get_models.md
+++ b/cli-reference/commands/bl_get_models.md
@@ -4,7 +4,7 @@ slug: bl_get_models
 ---
 ## bl get models
 
-Get a Model
+List all models or get details of a specific one
 
 ```
 bl get models [flags]
@@ -29,5 +29,5 @@ bl get models [flags]
 
 ### SEE ALSO
 
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 

--- a/cli-reference/commands/bl_get_policies.md
+++ b/cli-reference/commands/bl_get_policies.md
@@ -4,7 +4,7 @@ slug: bl_get_policies
 ---
 ## bl get policies
 
-Get a Policy
+List all policies or get details of a specific one
 
 ```
 bl get policies [flags]
@@ -29,5 +29,5 @@ bl get policies [flags]
 
 ### SEE ALSO
 
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 

--- a/cli-reference/commands/bl_get_previews.md
+++ b/cli-reference/commands/bl_get_previews.md
@@ -4,7 +4,7 @@ slug: bl_get_previews
 ---
 ## bl get previews
 
-Get a Preview
+List all previews or get details of a specific one
 
 ```
 bl get previews [flags]
@@ -29,5 +29,5 @@ bl get previews [flags]
 
 ### SEE ALSO
 
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 

--- a/cli-reference/commands/bl_get_previewtokens.md
+++ b/cli-reference/commands/bl_get_previewtokens.md
@@ -4,7 +4,7 @@ slug: bl_get_previewtokens
 ---
 ## bl get previewtokens
 
-Get a PreviewToken
+List all previewtokens or get details of a specific one
 
 ```
 bl get previewtokens [flags]
@@ -29,5 +29,5 @@ bl get previewtokens [flags]
 
 ### SEE ALSO
 
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 

--- a/cli-reference/commands/bl_get_sandboxes.md
+++ b/cli-reference/commands/bl_get_sandboxes.md
@@ -4,7 +4,7 @@ slug: bl_get_sandboxes
 ---
 ## bl get sandboxes
 
-Get a Sandbox
+List all sandboxes or get details of a specific one
 
 ```
 bl get sandboxes [flags]
@@ -29,5 +29,5 @@ bl get sandboxes [flags]
 
 ### SEE ALSO
 
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 

--- a/cli-reference/commands/bl_get_volumes.md
+++ b/cli-reference/commands/bl_get_volumes.md
@@ -4,7 +4,7 @@ slug: bl_get_volumes
 ---
 ## bl get volumes
 
-Get a Volume
+List all volumes or get details of a specific one
 
 ```
 bl get volumes [flags]
@@ -29,5 +29,5 @@ bl get volumes [flags]
 
 ### SEE ALSO
 
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 

--- a/cli-reference/commands/bl_get_volumetemplates.md
+++ b/cli-reference/commands/bl_get_volumetemplates.md
@@ -4,7 +4,7 @@ slug: bl_get_volumetemplates
 ---
 ## bl get volumetemplates
 
-Get a VolumeTemplate
+List all volumetemplates or get details of a specific one
 
 ```
 bl get volumetemplates [flags]
@@ -29,5 +29,5 @@ bl get volumetemplates [flags]
 
 ### SEE ALSO
 
-* [bl get](/cli-reference/commands/bl_get)	 - Get a resource
+* [bl get](/cli-reference/commands/bl_get)	 - List or retrieve Blaxel resources in your workspace
 

--- a/cli-reference/commands/bl_login.md
+++ b/cli-reference/commands/bl_login.md
@@ -70,5 +70,5 @@ bl login [workspace] [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_logout.md
+++ b/cli-reference/commands/bl_logout.md
@@ -59,5 +59,5 @@ bl logout [workspace] [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_logs.md
+++ b/cli-reference/commands/bl_logs.md
@@ -4,7 +4,7 @@ slug: bl_logs
 ---
 ## bl logs
 
-View logs for a resource
+View and stream logs for agents, jobs, sandboxes, and functions
 
 ### Synopsis
 
@@ -135,5 +135,5 @@ bl logs RESOURCE_TYPE RESOURCE_NAME [NESTED_ARGS...] [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_new.md
+++ b/cli-reference/commands/bl_new.md
@@ -4,7 +4,7 @@ slug: bl_new
 ---
 ## bl new
 
-Create a new blaxel resource (agent, mcp, sandbox, job, volume-template)
+Scaffold a new project from a template (agent, mcp, sandbox, job, volume-template)
 
 ### Synopsis
 
@@ -96,5 +96,5 @@ bl new [type] [directory] [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_push.md
+++ b/cli-reference/commands/bl_push.md
@@ -4,7 +4,7 @@ slug: bl_push
 ---
 ## bl push
 
-Build and push an image to the Blaxel registry
+Build and push a container image to the Blaxel registry
 
 ### Synopsis
 
@@ -67,5 +67,5 @@ bl push [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_run.md
+++ b/cli-reference/commands/bl_run.md
@@ -4,7 +4,7 @@ slug: bl_run
 ---
 ## bl run
 
-Run a resource on blaxel
+Execute a resource (agent, model, job, function, sandbox)
 
 ### Synopsis
 
@@ -121,5 +121,5 @@ bl run resource-type resource-name [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_serve.md
+++ b/cli-reference/commands/bl_serve.md
@@ -4,7 +4,7 @@ slug: bl_serve
 ---
 ## bl serve
 
-Serve a blaxel project
+Start a local development server for your project
 
 ### Synopsis
 
@@ -87,5 +87,5 @@ bl serve [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_token.md
+++ b/cli-reference/commands/bl_token.md
@@ -56,5 +56,5 @@ bl token [workspace] [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_upgrade.md
+++ b/cli-reference/commands/bl_upgrade.md
@@ -52,5 +52,5 @@ bl upgrade [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_version.md
+++ b/cli-reference/commands/bl_version.md
@@ -28,5 +28,5 @@ bl version [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 

--- a/cli-reference/commands/bl_workspaces.md
+++ b/cli-reference/commands/bl_workspaces.md
@@ -4,7 +4,7 @@ slug: bl_workspaces
 ---
 ## bl workspaces
 
-List all workspaces with the current workspace highlighted, set optionally a new current workspace
+List workspaces or switch the current workspace
 
 ### Synopsis
 
@@ -70,5 +70,5 @@ bl workspaces [workspace] [flags]
 
 ### SEE ALSO
 
-* [bl](/cli-reference/commands/bl)	 - Blaxel CLI is a command line tool to interact with Blaxel APIs.
+* [bl](/cli-reference/commands/bl)	 - Blaxel CLI - manage and deploy AI agents, sandboxes, and resources
 


### PR DESCRIPTION
Automated update of CLI docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Automated update of CLI reference documentation, replacing terse command descriptions with more descriptive ones across 46 files. All changes are purely documentation text updates — no code, logic, or configuration is modified.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 172b8d0d002cfb68390a12e3ba7856a3ca49d46d.</sup>
<!-- /MENDRAL_SUMMARY -->