### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -827,6 +827,11 @@ components:
         resourceType:
           type: string
           description: The resource type of the image.
+        sourceWorkspace:
+          type: string
+          description: If this image is shared from another workspace, this field
+            contains the name of the source workspace. Empty for non-shared images.
+          readOnly: true
         status:
           $ref: '#/components/schemas/Status'
         updatedAt:
@@ -4389,6 +4394,117 @@ paths:
     - description: Name of the container image repository
       in: path
       name: imageName
+      required: true
+      schema:
+        type: string
+  /images/{resourceType}/{imageName}/share:
+    get:
+      description: Returns the list of workspaces that a container image is currently
+        shared with.
+      operationId: ListImageShares
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  type: string
+                type: array
+          description: successful operation
+        "404":
+          description: image not found
+      security:
+      - OAuth2:
+        - images:get
+      - ApiKeyAuth: []
+      summary: List image shares
+      tags:
+      - images
+    parameters:
+    - description: Resource type (agents, functions, sandboxes, jobs)
+      in: path
+      name: resourceType
+      required: true
+      schema:
+        type: string
+    - description: Name of the container image repository
+      in: path
+      name: imageName
+      required: true
+      schema:
+        type: string
+    post:
+      description: Shares a container image with another workspace by copying the
+        metadata record. The underlying storage (S3) data is not duplicated. The target
+        workspace must belong to the same account.
+      operationId: ShareImage
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                targetWorkspace:
+                  description: Name of the workspace to share the image with
+                  type: string
+              required:
+              - targetWorkspace
+              type: object
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Image'
+          description: successful operation
+        "400":
+          description: invalid request
+        "404":
+          description: image not found
+      security:
+      - OAuth2:
+        - images:share
+      - ApiKeyAuth: []
+      summary: Share a container image
+      tags:
+      - images
+  /images/{resourceType}/{imageName}/share/{targetWorkspace}:
+    delete:
+      description: Revokes sharing of a container image with a target workspace. Removes
+        the metadata copy from the target workspace. The source image is not affected.
+      operationId: UnshareImage
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Image'
+          description: successful operation
+        "404":
+          description: image or share not found
+      security:
+      - OAuth2:
+        - images:share
+      - ApiKeyAuth: []
+      summary: Unshare a container image
+      tags:
+      - images
+    parameters:
+    - description: Resource type (agents, functions, sandboxes, jobs)
+      in: path
+      name: resourceType
+      required: true
+      schema:
+        type: string
+    - description: Name of the container image repository
+      in: path
+      name: imageName
+      required: true
+      schema:
+        type: string
+    - description: Name of the target workspace to revoke sharing from
+      in: path
+      name: targetWorkspace
       required: true
       schema:
         type: string


### PR DESCRIPTION
Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds image sharing API endpoints (`GET/POST /images/{resourceType}/{imageName}/share` and `DELETE /images/{resourceType}/{imageName}/share/{targetWorkspace}`) to the OpenAPI spec, along with a new `sourceWorkspace` field on the Image schema to indicate cross-workspace shared images.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit fa4fe154bd58701bbacb81638df58821ddbac770.</sup>
<!-- /MENDRAL_SUMMARY -->