### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -1294,11 +1294,6 @@ components:
           type: string
           description: Container image built by Blaxel when deploying with 'bl deploy'.
             This field is auto-populated during deployment.
-        maxConcurrentTasks:
-          type: integer
-          description: Maximum number of tasks that can run simultaneously within
-            a single execution
-          example: 10
         maxRetries:
           type: integer
           description: Number of automatic retry attempts for failed tasks before


### PR DESCRIPTION
Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Automated removal of the `maxConcurrentTasks` field from the controlplane API spec, syncing docs with upstream changes.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 25899fa4224ec89b2c7b8ec0bcc549e1a61fb2af.</sup>
<!-- /MENDRAL_SUMMARY -->