### PR TITLE
fix: update OpenAI tutorial

### DIFF
--- a/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
+++ b/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
@@ -160,10 +160,6 @@ The agent will create and deploy a Blaxel sandbox using the `blaxel/base-image` 
 
 ## 7. Deploy the agent on Blaxel
 
-#######
-TODO - Testing needed after SDK is publicly available for pip install to work
-#######
-
 You're now ready to deploy the agent on Blaxel. When deploying to Blaxel, your workloads are served optimally to dramatically accelerate cold-start and latency while enforcing your deployment policies.
 
 Deploying the agent is as simple as running the following command:


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes a TODO comment block from the OpenAI Agents SDK deployment tutorial that was gating section 7 pending SDK public availability for pip install.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 93f4232e5a21adabd2f8ef254828e4f5a4df0f5d.</sup>
<!-- /MENDRAL_SUMMARY -->