### PR TITLE
fix: update OpenAI tutorial

### DIFF
--- a/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
+++ b/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
@@ -162,7 +162,15 @@ The agent will create and deploy a Blaxel sandbox using the `blaxel/base-image` 
 
 You're now ready to deploy the agent on Blaxel. When deploying to Blaxel, your workloads are served optimally to dramatically accelerate cold-start and latency while enforcing your deployment policies.
 
-Deploying the agent is as simple as running the following command:
+First, create a `requirements.txt` file in the project directory with the following dependencies:
+
+```shell
+fastapi>=0.135.3
+uvicorn>=0.35.0
+openai-agents[blaxel]
+```
+
+Then, deploy the agent by running the following command:
 
 ```shell
 bl deploy


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `requirements.txt` code block to the OpenAI Agents SDK deployment tutorial, listing `fastapi`, `uvicorn`, and `openai-agents[blaxel]` as prerequisites before the `bl deploy` step.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 56b0be974dd131a6488630931b7db7c0bb871d5e.</sup>
<!-- /MENDRAL_SUMMARY -->