### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -2481,6 +2481,11 @@ components:
           example: 4096
         ports:
           $ref: '#/components/schemas/Ports'
+        terminationGracePeriodSeconds:
+          type: integer
+          description: Duration in seconds the pod needs to terminate gracefully.
+            Defaults to 0 for immediate termination.
+          example: 30
         ttl:
           type: string
           description: Time-to-live duration after which the sandbox is automatically


### PR DESCRIPTION
Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `terminationGracePeriodSeconds` field to the sandbox component schema in the OpenAPI spec, documenting the duration in seconds for graceful pod termination with a default of 0 (immediate termination).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4a520f43a2816e6dbbde36ecba4a609c14bcb641.</sup>
<!-- /MENDRAL_SUMMARY -->