### PR TITLE
fix: add warning for API key

### DIFF
--- a/Integrations/AgentMail.mdx
+++ b/Integrations/AgentMail.mdx
@@ -37,6 +37,10 @@ AGENTMAIL_API_KEY=   # your AgentMail API key
 
 Create a `.env` file in the project root with these variables, or set them in your deployment environment.
 
+<Warning>
+The `AGENTMAIL_API_KEY` variable is required. If it is missing or not correctly set, the AgentMail client will fail to authenticate and return a **403 Forbidden** error at runtime. Confirm this variable is configured before deploying.
+</Warning>
+
 ## Deploy the agent
 
 [Deploy the agent](../Agents/Deploy-an-agent) on Blaxel. Once the agent is deployed, retrieve its [inference endpoint](../Agents/Query-agents).


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `<Warning>` callout in the AgentMail integration doc to alert users that `AGENTMAIL_API_KEY` is required and that omitting it causes a 403 Forbidden error at runtime.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit fc898fa37671919d30dffbe52b34eef17e52989e.</sup>
<!-- /MENDRAL_SUMMARY -->