### PR TITLE
chore: auto-update cli docs from upstream

### DIFF
--- a/cli-reference/commands/bl_get_mcp-hub.md
+++ b/cli-reference/commands/bl_get_mcp-hub.md
@@ -14,14 +14,12 @@ These provide ready-to-use tool integrations (e.g. GitHub, Slack,
 databases). Connect one to your agent by creating an integration
 connection with 'bl apply -f connection.yaml':
 
-```yaml
   apiVersion: blaxel/v1alpha1
   kind: IntegrationConnection
   metadata:
     name: my-github
   spec:
     integration: <integration-from-hub>
-```
 
 Output formats:
   -o json   Machine-readable JSON array

--- a/cli-reference/commands/bl_get_sandbox-hub.md
+++ b/cli-reference/commands/bl_get_sandbox-hub.md
@@ -14,14 +14,12 @@ Each image comes with pre-installed tools, runtimes, and configurations.
 Use the 'image' field value in your sandbox YAML spec when deploying
 with 'bl apply -f sandbox.yaml':
 
-```yaml
   apiVersion: blaxel/v1alpha1
   kind: Sandbox
   metadata:
     name: my-sandbox
   spec:
     image: <image-from-hub>
-```
 
 Output formats:
   -o json   Machine-readable JSON array


### PR DESCRIPTION
Automated update of CLI docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the opening and closing YAML code fence markers (` ```yaml ` and ` ``` `) from two CLI reference docs, leaving the YAML example blocks as plain indented text rather than fenced code blocks.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 73eb0f0658d1187c3dfbad8d9cb669dc55ff63e7.</sup>
<!-- /MENDRAL_SUMMARY -->