### PR TITLE
chore: auto-update cli docs from upstream

### DIFF
--- a/cli-reference/commands/bl_run.md
+++ b/cli-reference/commands/bl_run.md
@@ -87,6 +87,12 @@ bl run resource-type resource-name [flags]
   # Get JSON output for machine parsing
   bl run agent my-agent --data '{"inputs": "hello"}' -o json
 
+  # List a directory in a sandbox via the filesystem API (double slash => absolute path, bypassing the sandbox workdir)
+  bl run sandbox my-sandbox --method GET --path /filesystem//tmp
+
+  # Read a file from a sandbox via the filesystem API
+  bl run sandbox my-sandbox --method GET --path /filesystem//app/main.py
+
   # Execute a command in a sandbox
   bl run sandbox my-sandbox --path /process --data '{"command": "echo hello"}'
 


### PR DESCRIPTION
Automated update of CLI docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds three new CLI usage examples to the `bl run` documentation for sandbox filesystem API interactions, demonstrating directory listing and file reading via absolute paths using the double-slash convention.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b6d572e537e0135076470516bba8aa01efa2b035.</sup>
<!-- /MENDRAL_SUMMARY -->