### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -842,6 +842,32 @@ components:
           type: string
           description: The workspace of the image.
           readOnly: true
+    ImageShareTarget:
+      type: object
+      properties:
+        accountId:
+          type: string
+          description: ID of the account that owns the target workspace.
+        accountOwnerEmail:
+          type: string
+          description: Email of the account owner for the target workspace (when available).
+        pendingShareId:
+          type: string
+          description: ID of the pending share record when status is "pending".
+        status:
+          type: string
+          description: '"active" when the share is applied in the target workspace,
+            "pending" when it is awaiting accept on a cross-account share.'
+        workspace:
+          type: string
+          description: The workspace the image is shared with.
+        workspaceDisplayName:
+          type: string
+          description: Display name of the target workspace.
+      required:
+      - workspace
+      - accountId
+      - status
     ImageSpec:
       type: object
       properties:
@@ -1633,6 +1659,88 @@ components:
           type: string
           description: The user or service account who updated the resource
           readOnly: true
+    PendingImageShare:
+      type: object
+      description: Pending cross-account image share awaiting approval from the destination
+        workspace
+      allOf:
+      - $ref: '#/components/schemas/TimeFields'
+      - $ref: '#/components/schemas/OwnerFields'
+      - properties:
+          expiresAt:
+            type: string
+            description: The date and time when the pending share expires
+          id:
+            type: string
+            description: Unique identifier for the pending image share
+          imageName:
+            type: string
+            description: Image name (repository)
+          resourceType:
+            type: string
+            description: Resource type (agent, function, sandbox, job)
+          sharedBy:
+            type: string
+            description: User sub who initiated the share
+          sourceAccountId:
+            type: string
+            description: Source account ID
+          sourceWorkspace:
+            type: string
+            description: Source workspace name
+          targetAccountId:
+            type: string
+            description: Target account ID
+          targetWorkspace:
+            type: string
+            description: Target workspace name
+    PendingImageShareRender:
+      type: object
+      description: Rendered pending image share with source/target workspace metadata
+      properties:
+        createdAt:
+          type: string
+          description: Creation date
+        expiresAt:
+          type: string
+          description: Expiration date
+        hasConflict:
+          type: boolean
+          description: Whether the target workspace already has an image with the
+            same name (potential conflict)
+        id:
+          type: string
+          description: Unique identifier for the pending image share
+        imageName:
+          type: string
+          description: Image name (repository)
+        resourceType:
+          type: string
+          description: Resource type (agent, function, sandbox, job)
+        sharedBy:
+          type: string
+          description: User sub who initiated the share
+        sharedByEmail:
+          type: string
+          description: Email of the user who initiated the share
+        sourceAccountId:
+          type: string
+          description: Source account ID
+        sourceWorkspace:
+          type: string
+          description: Source workspace name
+        sourceWorkspaceDisplayName:
+          type: string
+          description: Source workspace display name
+        targetAccountId:
+          type: string
+          description: Target account ID
+        targetWorkspace:
+          type: string
+          description: Target workspace name
+        targetWorkspaceDisplayName:
+          type: string
+          description: Target workspace display name
     PendingInvitation:
       type: object
       description: Pending invitation in workspace
@@ -4435,14 +4543,22 @@ paths:
         type: string
     post:
       description: Shares a container image with another workspace by copying the
-        metadata record. The underlying storage (S3) data is not duplicated. The target
-        workspace must belong to the same account.
+        metadata record. The underlying storage (S3) data is not duplicated. For same-account
+        targets the share is applied immediately. For cross-account targets, a pending
+        image share is created and must be explicitly accepted by an admin of the
+        target workspace; the correct target account ID must be supplied as an anti-spam
+        measure.
       operationId: ShareImage
       requestBody:
         content:
           application/json:
             schema:
               properties:
+                targetAccountId:
+                  description: Account ID of the target workspace. Required when the
+                    target workspace belongs to a different account than the source
+                    workspace (anti-spam).
+                  type: string
                 targetWorkspace:
                   description: Name of the workspace to share the image with
                   type: string
@@ -4456,11 +4572,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Image'
-          description: successful operation
+          description: successful operation (same-account share, applied immediately)
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PendingImageShare'
+          description: pending approval from target workspace admin
         "400":
           description: invalid request
         "404":
           description: image not found
+        "409":
+          description: image conflict in target workspace
       security:
       - OAuth2:
         - images:share
@@ -5524,6 +5648,106 @@ paths:
       summary: List model revisions
       tags:
       - models
+  /pending-image-shares:
+    get:
+      description: Lists pending cross-account image shares targeting the caller's
+        workspace (incoming) or originating from it (outgoing). Expired shares are
+        cleaned up opportunistically.
+      operationId: ListPendingImageShares
+      parameters:
+      - description: 'Direction of pending shares: "incoming" (default) or "outgoing"'
+        in: query
+        name: direction
+        required: false
+        schema:
+          enum:
+          - incoming
+          - outgoing
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/PendingImageShareRender'
+                type: array
+          description: successful operation
+      security:
+      - OAuth2:
+        - images:share
+      - ApiKeyAuth: []
+      summary: List pending image shares
+      tags:
+      - images
+  /pending-image-shares/{pendingShareId}/accept:
+    parameters:
+    - description: ID of the pending image share
+      in: path
+      name: pendingShareId
+      required: true
+      schema:
+        type: string
+    post:
+      description: Accepts a pending cross-account image share and copies the image
+        metadata to the target workspace. Caller must be an admin of the target workspace.
+      operationId: AcceptImageShare
+      parameters:
+      - description: When true, overwrite conflicting tags in the target workspace
+          instead of returning 409.
+        in: query
+        name: force
+        required: false
+        schema:
+          type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Image'
+          description: successful operation
+        "403":
+          description: forbidden
+        "404":
+          description: pending image share not found
+        "409":
+          description: image conflict in target workspace
+        "410":
+          description: pending image share expired
+      security:
+      - OAuth2:
+        - images:share
+      - ApiKeyAuth: []
+      summary: Accept a pending image share
+      tags:
+      - images
+  /pending-image-shares/{pendingShareId}/decline:
+    parameters:
+    - description: ID of the pending image share
+      in: path
+      name: pendingShareId
+      required: true
+      schema:
+        type: string
+    post:
+      description: Declines a pending cross-account image share. Caller must be an
+        admin of the target workspace.
+      operationId: DeclineImageShare
+      responses:
+        "204":
+          description: successfully declined
+        "403":
+          description: forbidden
+        "404":
+          description: pending image share not found
+      security:
+      - OAuth2:
+        - images:share
+      - ApiKeyAuth: []
+      summary: Decline a pending image share
+      tags:
+      - images
   /policies:
     get:
       description: Returns all governance policies in the workspace. Policies control


### PR DESCRIPTION
Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds cross-account image sharing support to the API docs, introducing new schemas (`ImageShareTarget`, `PendingImageShare`, `PendingImageShareRender`) and endpoints for listing, accepting, and declining pending image shares. The `ShareImage` endpoint is updated to support cross-account targets with a pending approval flow.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 1a46519a95c2d700cf3d4869a2be744b80fae96d.</sup>
<!-- /MENDRAL_SUMMARY -->