### PR TITLE
docs: document  read-only drive mounts

### DIFF
--- a/Agent-drive/Overview.mdx
+++ b/Agent-drive/Overview.mdx
@@ -177,8 +177,8 @@ You can mount a drive in read-only mode:
 
 ```tsx TypeScript
 await sandbox.drives.mount({
-  name: "my-drive",
-  path: "/mnt/shared",
+  driveName: "my-drive",
+  mountPath: "/mnt/shared",
   readOnly: true,
 });
 ```

--- a/Agent-drive/Overview.mdx
+++ b/Agent-drive/Overview.mdx
@@ -185,8 +185,8 @@ await sandbox.drives.mount({
 
 ```python Python
 await sandbox.drives.mount(
-    name="my-drive",
-    path="/mnt/shared",
+    drive_name="my-drive",
+    mount_path="/mnt/shared",
     read_only=True,
 )
 ```

--- a/Agent-drive/Overview.mdx
+++ b/Agent-drive/Overview.mdx
@@ -169,6 +169,38 @@ await sandbox.drives.mount(
   `drivePath` / `drive_path` is a mount point convenience, not a security boundary. Once a drive is mounted at any location in a sandbox, the sandbox has sufficient credentials to access all other drives in the same workspace. This is a temporary constraint during the preview phase; the final release will include fine-grained access control.
 </Warning>
 
+### Mount a drive as read-only
+
+You can mount a drive in read-only mode:
+
+<CodeGroup>
+
+```tsx TypeScript
+await sandbox.drives.mount({
+  name: "my-drive",
+  path: "/mnt/shared",
+  readOnly: true,
+});
+```
+
+```python Python
+await sandbox.drives.mount(
+    name="my-drive",
+    path="/mnt/shared",
+    read_only=True,
+)
+```
+
+</CodeGroup>
+
+The same drive can be mounted read-write in one sandbox and read-only in others. However, any write attempt to a drive mounted as read-only will fail with a permission error.
+
+<Warning>
+Read-only mode is enforced at mount time, not at the storage/system level. Therefore,  if an agent running inside the sandbox manages to read the drive access token, located at `/var/run/secrets/blaxel.ai/identity/token` and re-invoke the `blfs` command itself, it could remount the drive in read-write mode and bypass the read-only restriction.
+
+To make the read-only guarantee effective in an adversarial/agentic setup, you should restrict the agent's access to `/var/run/secrets/blaxel.ai/identity/token`, and also block the `blfs` binary from the agent's `PATH` / execution scope.
+</Warning>
+
 ## List mounted drives
 
 List all drives currently mounted to a sandbox:


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Documents the read-only drive mount feature, including code examples for TypeScript and Python, and a security warning about the enforcement boundary and bypass vector via the `blfs` binary and identity token.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4cc4e1e8be3ab5bfa0f6384ec5c3b03141259005.</sup>
<!-- /MENDRAL_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
