### PR TITLE
docs: clarify logger usage

### DIFF
--- a/Agents/Develop-an-agent-py.mdx
+++ b/Agents/Develop-an-agent-py.mdx
@@ -348,13 +348,17 @@ import blaxel.core
 
 When agents and tools are deployed on Blaxel, request logging and tracing happens automatically.
 
+<Note>
+  You do not need to call `logging.basicConfig()` in your agent code. Importing any `blaxel.*` module automatically initializes the logger with the correct formatter for the Blaxel platform.
+</Note>
+
 To add your own custom logs that you can view in the Blaxel Console, use the Python default logger.
 
-```bash
+```python
 import logging
 
-logger = getLogger(__name__)
-logger.info("Hello, world!");
+logger = logging.getLogger(__name__)
+logger.info("Hello, world!")
 ```
 
 ## Template directory reference


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a documentation code snippet for Python logging: corrects the code block language tag from `bash` to `python`, fixes `getLogger` to `logging.getLogger`, removes a stray semicolon, and adds a `<Note>` clarifying that `logging.basicConfig()` is not needed when using Blaxel modules.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8601f327ca0ed4cf0982c2d7843a6171b509df7b.</sup>
<!-- /MENDRAL_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
