### PR TITLE
docs: include new error codes and retry strategy

### DIFF
--- a/Sandboxes/best-practices.mdx
+++ b/Sandboxes/best-practices.mdx
@@ -53,7 +53,7 @@ Use [lifecycle policies and time-to-live (TTL)](../Sandboxes/Expiration) setting
 
 ## Retry strategically in case of errors
 
-Blaxel's management API returns [structured error responses](/api-reference/error-codes) in case of sandbox creation or connection failures. To handle these errors, we recommend the following strategy:
+Blaxel returns [structured error responses](/troubleshooting/error-codes) in case of sandbox creation or connection failures. To handle these errors, we recommend the following strategy:
 
 1. First, check the origin of the error.
 
@@ -65,4 +65,4 @@ Blaxel's management API returns [structured error responses](/api-reference/erro
     - `WORKLOAD_NOT_FOUND`: The sandbox record itself doesn't exist in the platform (deleted, never created, or wrong name). Definitely re-create. Not retryable.
     - `ROUTE_NOT_FOUND`: The URL is wrong. This is a URL construction bug, not a sandbox availability issue. Don't re-create, fix the URL. The SDK's `sandbox.metadata.url` is the canonical source.
 
-For more information, refer to the [list of error codes](/api-reference/error-codes).
+For more information, refer to the [list of error codes](/troubleshooting/error-codes).

--- a/Sandboxes/best-practices.mdx
+++ b/Sandboxes/best-practices.mdx
@@ -56,11 +56,13 @@ Use [lifecycle policies and time-to-live (TTL)](../Sandboxes/Expiration) setting
 Blaxel's management API returns [structured error responses](/api-reference/error-codes) in case of sandbox creation or connection failures. To handle these errors, we recommend the following strategy:
 
 1. First, check the origin of the error.
-Look at `error.origin` (or the `X-Blaxel-Source header`). If it is not `platform`, the 404 came from the application itself (e.g. a missing file), not from our platform. You should not re-create in that case.
+
+    Look at `error.origin` (or the `X-Blaxel-Source header`). If it is not `platform`, the 404 came from the application itself (e.g. a missing file), not from Blaxel. You should not re-create in that case.
 
 2. Then, branch on `error.code`:
-- `WORKLOAD_UNAVAILABLE`: The sandbox record exists but no healthy replica is currently serving it. This is the "sandbox is down" signal. It's marked `retryable: true`, so retry with exponential backoff (500ms to 30s, give up after ~60s). If retries keep failing, treat it as gone and re-create.
-- `WORKLOAD_NOT_FOUND`: The sandbox record itself doesn't exist in the platform (deleted, never created, or wrong name). Definitely re-create. Not retryable.
-- `ROUTE_NOT_FOUND`: The URL is wrong. This is a URL construction bug, not a sandbox availability issue. Don't re-create, fix the URL. The SDK's `sandbox.metadata.url` is the canonical source.
+
+    - `WORKLOAD_UNAVAILABLE`: The sandbox record exists but no healthy replica is currently serving it. This is the "sandbox is down" signal. It's marked `retryable: true`, so retry with exponential backoff (500ms to 30s, give up after ~60s). If retries keep failing, treat it as gone and re-create.
+    - `WORKLOAD_NOT_FOUND`: The sandbox record itself doesn't exist in the platform (deleted, never created, or wrong name). Definitely re-create. Not retryable.
+    - `ROUTE_NOT_FOUND`: The URL is wrong. This is a URL construction bug, not a sandbox availability issue. Don't re-create, fix the URL. The SDK's `sandbox.metadata.url` is the canonical source.
 
 For more information, refer to the [list of error codes](/api-reference/error-codes).

--- a/Sandboxes/best-practices.mdx
+++ b/Sandboxes/best-practices.mdx
@@ -50,3 +50,17 @@ Use [lifecycle policies and time-to-live (TTL)](../Sandboxes/Expiration) setting
 <Note>
   In [quota tiers 0 and 1](https://app.blaxel.ai/account/quotas), a maximum TTL is enforced on all sandboxes. On quota tier 2 and above, no expiration policy is set by default.
 </Note>
+
+## Retry strategically in case of errors
+
+Blaxel's management API returns [structured error responses](/api-reference/error-codes) in case of sandbox creation or connection failures. To handle these errors, we recommend the following strategy:
+
+1. First, check the origin of the error.
+Look at `error.origin` (or the `X-Blaxel-Source header`). If it is not `platform`, the 404 came from the application itself (e.g. a missing file), not from our platform. You should not re-create in that case.
+
+2. Then, branch on `error.code`:
+- `WORKLOAD_UNAVAILABLE`: The sandbox record exists but no healthy replica is currently serving it. This is the "sandbox is down" signal. It's marked `retryable: true`, so retry with exponential backoff (500ms to 30s, give up after ~60s). If retries keep failing, treat it as gone and re-create.
+- `WORKLOAD_NOT_FOUND`: The sandbox record itself doesn't exist in the platform (deleted, never created, or wrong name). Definitely re-create. Not retryable.
+- `ROUTE_NOT_FOUND`: The URL is wrong. This is a URL construction bug, not a sandbox availability issue. Don't re-create, fix the URL. The SDK's `sandbox.metadata.url` is the canonical source.
+
+For more information, refer to the [list of error codes](/api-reference/error-codes).

--- a/api-reference/error-codes.mdx
+++ b/api-reference/error-codes.mdx
@@ -1,0 +1,51 @@
+---
+title: "Error codes"
+description: "Review error codes returned by the management API"
+---
+
+Blaxel's management API returns structured error responses in case of request failure. These error responses include additional information designed for coding agents and LLMs.
+
+Every error has a consistent JSON body and response header, as shown below:
+
+```json
+{
+  "error": {
+    "action": "Stop. URL does not match a Blaxel route. Use `https://{sbx|agt|mcp|mdl|job}-{name}-{workspace}.{region}.bl.run[/{path}]` for workloads or `https://{preview_id}.preview.bl.run/{path}` for previews. Get the canonical URL from the SDK (e.g. `sandbox.metadata.url`), not by hand.",
+    "code": "ROUTE_NOT_FOUND",
+    "do_not": "Do not retry, do not guess URLs, do not use `run.blaxel.ai` (not served).",
+    "docs_url": "https://docs.blaxel.ai/Sandboxes/Ports.md",
+    "message": "Preview not found: xxx",
+    "origin": "platform",
+    "retryable": false,
+    "status": 404,
+    "timestamp": "2026-04-23T14:49:43+00:00"
+  }
+}
+```
+
+| Field | Description |
+|---|---|
+| `error.action` | Agent-readable actions to be taken |
+| `error.code` | Machine-readable error code |
+| `error.do_not` | Agent-readable actions not to be taken |
+| `error.docs_url` | Documentation related to this error |
+| `error.message` | Human-readable description |
+| `error.origin` | `"platform"` when emitted by Blaxel; otherwise absent |
+| `error.retryable` | Whether the request can return a different response if it is retried |
+| `error.status` | HTTP status code (same as HTTP response header) |
+| `error.timestamp` | Timestamp in ISO-8601 format |
+
+## Error codes
+
+| Code | HTTP | Retryable | When emitted |
+|---|---|---|---|
+| `ROUTE_NOT_FOUND` | 404 | No | Request path couldn't be parsed into a known workload, preview, or sandbox subdomain shape |
+| `WORKLOAD_NOT_FOUND` | 404 | No | Workload record doesn't exis |
+| `WORKSPACE_NOT_FOUND` | 404 | No | Workspace couldn't be resolved for a deployment-subdomain request |
+| `WORKLOAD_UNAVAILABLE` | 404 | **Yes** | Workload exists but no healthy replica is currently serving it |
+| `AUTHENTICATION_REQUIRED` | 401 | No | Credentials missing |
+| `AUTHENTICATION_FAILED` | 401 | No | Credentials present but invalid or rejected |
+| `FORBIDDEN` | 403 | No | Authenticated but not authorized |
+| `BAD_REQUEST` | 400 | No | Malformed request |
+| `USAGE_LIMIT_EXCEEDED` | 402 | No | Plan quota reached |
+| `POLICY_VIOLATION` | varies | No | Policy rule rejection |

--- a/api-reference/error-codes.mdx
+++ b/api-reference/error-codes.mdx
@@ -40,7 +40,7 @@ Every error has a consistent JSON body and response header, as shown below:
 | Code | HTTP | Retryable | When emitted |
 |---|---|---|---|
 | `ROUTE_NOT_FOUND` | 404 | No | Request path couldn't be parsed into a known workload, preview, or sandbox subdomain shape |
-| `WORKLOAD_NOT_FOUND` | 404 | No | Workload record doesn't exis |
+| `WORKLOAD_NOT_FOUND` | 404 | No | Workload record doesn't exist |
 | `WORKSPACE_NOT_FOUND` | 404 | No | Workspace couldn't be resolved for a deployment-subdomain request |
 | `WORKLOAD_UNAVAILABLE` | 404 | **Yes** | Workload exists but no healthy replica is currently serving it |
 | `AUTHENTICATION_REQUIRED` | 401 | No | Credentials missing |

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -29,5 +29,3 @@ See the reference documentation below for more information:
 <Card title="Inference API" icon="earth-americas" href="/api-reference/inference">Run inference requests on your deployments by API. </Card>
 
 <Card title="Management API" icon="cubes" href="/api-reference/agents/list-all-agents"> API to manage agents, functions, policies and much more.</Card>
-
-<Card title="Error codes" icon="cubes" href="/api-reference/error-codes">See the list of error codes.</Card>

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -6,13 +6,13 @@ description: 'Authenticate and interact with all Blaxel resources using REST API
 
 ---
 
-Blaxel APIs allow you to interact with all resources inside of and across your workspace(s). 
+Blaxel APIs allow you to interact with all resources inside of and across your workspace(s).
 
 ## Get started
 
 Authentication to the Blaxel APIs can either be done using [API keys](../Security/Access-tokens) created from the Blaxel console, or through a [classic OAuth 2.0 flow](../Security/Access-tokens).
 
-**API keys** allow you to get started quickly. Simply [generate an API key](../Security/Access-tokens) for your user or service account and use the API key as a bearer token in place of the authorization headers `Authorization` or `X-Blaxel-Authorization` in any call to the Blaxel APIs. 
+**API keys** allow you to get started quickly. Simply [generate an API key](../Security/Access-tokens) for your user or service account and use the API key as a bearer token in place of the authorization headers `Authorization` or `X-Blaxel-Authorization` in any call to the Blaxel APIs.
 
 For example, to list models:
 
@@ -24,10 +24,10 @@ curl 'https://api.blaxel.ai/v0/models' \
 
 To use **short-lived JWTs**, see [the guide on using an OAuth 2.0 flow](../Security/Access-tokens).
 
-## Blaxel APIs
+See the reference documentation below for more information:
 
-See the reference for any of the following APIs:
+<Card title="Inference API" icon="earth-americas" href="/api-reference/inference">Run inference requests on your deployments by API. </Card>
 
-<Card title="Inference API" icon="earth-americas" href="/api-reference/inference" > Run inference requests on your deployments by API. </Card>
+<Card title="Management API" icon="cubes" href="/api-reference/agents/list-all-agents"> API to manage agents, functions, policies and much more.</Card>
 
-<Card title="Management API" icon="cubes" href="/api-reference/agents/list-all-agents" > API to manage agents, functions, policies and much more.</Card>
+<Card title="Error codes" icon="cubes" href="/api-reference/error-codes">See the list of error codes.</Card>

--- a/docs.json
+++ b/docs.json
@@ -229,6 +229,7 @@
             "group": "Troubleshooting",
             "pages": [
               "troubleshooting",
+              "troubleshooting/error-codes",
               "troubleshooting/knowledge-base"
             ]
           }
@@ -311,8 +312,7 @@
           {
             "group": "Overview",
             "pages": [
-              "api-reference/introduction",
-              "api-reference/error-codes"
+              "api-reference/introduction"
             ]
           },
           {

--- a/docs.json
+++ b/docs.json
@@ -311,7 +311,8 @@
           {
             "group": "Overview",
             "pages": [
-              "api-reference/introduction"
+              "api-reference/introduction",
+              "api-reference/error-codes"
             ]
           },
           {

--- a/troubleshooting.mdx
+++ b/troubleshooting.mdx
@@ -115,9 +115,9 @@ To resolve this error, you have two options:
     Volumes are slower than the in-memory filesystem.
     </Note>
 
-## Sandbox commands return a `404 Workspace Not Found` error
+## Sandbox commands return a `404 WORKSPACE_NOT_FOUND` error
 
-This error occurs when a workspace is not provisioned correctly.
+This error occurs when a [workspace is not provisioned correctly](/api-reference/error-codes).
 
 To resolve this error, please contact us for support via [Discord](https://discord.gg/G3NqzUPcHP) or [online contact form](https://blaxel.ai/contact).
 

--- a/troubleshooting.mdx
+++ b/troubleshooting.mdx
@@ -117,7 +117,7 @@ To resolve this error, you have two options:
 
 ## Sandbox commands return a `404 WORKSPACE_NOT_FOUND` error
 
-This error occurs when a [workspace is not provisioned correctly](/api-reference/error-codes).
+This error occurs when a [workspace is not provisioned correctly](/troubleshooting/error-codes).
 
 To resolve this error, please contact us for support via [Discord](https://discord.gg/G3NqzUPcHP) or [online contact form](https://blaxel.ai/contact).
 

--- a/troubleshooting/error-codes.mdx
+++ b/troubleshooting/error-codes.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Error codes"
-description: "Review error codes returned by the management API"
+description: "Understand error codes returned by Blaxel"
 ---
 
-Blaxel's management API returns structured error responses in case of request failure. These error responses include additional information designed for coding agents and LLMs.
+Blaxel returns structured error responses in case of request failure. These error responses include additional information designed for coding agents and LLMs.
 
 Every error has a consistent JSON body and response header, as shown below:
 


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds structured error response documentation with a new `troubleshooting/error-codes.mdx` page covering error fields, codes, HTTP status, and retryability. Updates sandbox best practices with a retry strategy section and links the troubleshooting page to the new error codes doc. The latest commit moves the page from `api-reference/` to `troubleshooting/` and registers it in the nav.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 048848f8c6fc21397fa6a5cc68487c91405a7f74.</sup>
<!-- /MENDRAL_SUMMARY -->