### PR TITLE
fix: clarify expiration policies

### DIFF
--- a/Sandboxes/Expiration.mdx
+++ b/Sandboxes/Expiration.mdx
@@ -15,9 +15,12 @@ Automatic deletion differs from the automatic standby (_scale-to-zero_) which ha
 
 The following options are available for sandbox expiry and deletion:
 
-- expire after a total maximum lifetime (time-to-live or TTL) using the `ttl` parameter
-- expire after a period of inactivity using the `lifecycle.expirationPolicies` / `lifecycle.expiration_policies` parameter
+- expire after a total maximum lifetime (time-to-live or TTL) from creation using the `ttl` parameter
 - expire at a specific date using the `expires` parameter
+- expire based on a combination of one or more lifecycle policies, specified with the `lifecycle.expirationPolicies` / `lifecycle.expiration_policies` parameter
+  - `ttl-max-age`: Delete after total lifetime from creation (equivalent to `ttl`) (1h, 24h, 7d)
+  - `ttl-idle`: Delete after period of inactivity from last active time (1h, 24h, 7d)
+  - `date`: Delete at a specific date (equivalent to `expires`)
 
 <Note>
   If these parameters are absent, sandboxes will not be deleted.
@@ -88,8 +91,7 @@ sandbox = await SandboxInstance.create({
 
 Important notes:
 
-- The `ttl` parameter accepts a string with the following time units: `h` (hours), `d` (days), and `w` (weeks).
-- Lifecycle expirations policies also support types `ttl-max-age` and `date`: check out the [API reference](/api-reference/compute/update-sandbox) for full documentation.
+- Three lifecycle expiration policies are supported: `ttl-idle`, `ttl-max-age` and `date`. Check out the [API reference](/api-reference/compute/update-sandbox) for full documentation.- The `ttl`, `ttl-idle` and `ttl-max-age` parameters accept a string with the following time units: `h` (hours), `m` (minutes), `d` (days), and `w` (weeks).
 - You can combine multiple expiration policies. Whichever condition is met first will trigger the deletion.
 
 ## Update sandbox expiry rules

--- a/Sandboxes/Expiration.mdx
+++ b/Sandboxes/Expiration.mdx
@@ -91,7 +91,8 @@ sandbox = await SandboxInstance.create({
 
 Important notes:
 
-- Three lifecycle expiration policies are supported: `ttl-idle`, `ttl-max-age` and `date`. Check out the [API reference](/api-reference/compute/update-sandbox) for full documentation.- The `ttl`, `ttl-idle` and `ttl-max-age` parameters accept a string with the following time units: `h` (hours), `m` (minutes), `d` (days), and `w` (weeks).
+- Three lifecycle expiration policies are supported: `ttl-idle`, `ttl-max-age` and `date`. Check out the [API reference](/api-reference/compute/update-sandbox) for full documentation.
+- The `ttl`, `ttl-idle` and `ttl-max-age` parameters accept a string with the following time units: `h` (hours), `m` (minutes), `d` (days), and `w` (weeks).
 - You can combine multiple expiration policies. Whichever condition is met first will trigger the deletion.
 
 ## Update sandbox expiry rules

--- a/Sandboxes/best-practices.mdx
+++ b/Sandboxes/best-practices.mdx
@@ -45,11 +45,13 @@ Here's a table to help you decide:
 
 While we advocate for treating sandboxes as perpetual computers, not every machine needs to last forever. In production, you will inevitably accumulate a long tail of sandboxes that will never be called upon again (e.g., completed tasks, abandoned user sessions). To prevent digital clutter and unnecessary storage usage, you need automated garbage collection.
 
-Use [lifecycle policies and time-to-live (TTL)](../Sandboxes/Expiration) settings to define exactly when a computer should be retired. You can configure this based on idle duration (_e.g., delete if it hasn't been active for 7 days_) or absolute maximum age (_e.g., delete after 30 days_).
+Instead of writing scripts to manually filter and delete sandboxes, use [expiration parameters and lifecycle policies](../Sandboxes/Expiration) to automate when a sandbox should be retired. You can configure this based on idle duration (_e.g., delete if it hasn't been active for 7 days_) or absolute maximum age (_e.g., delete after 30 days_).
 
 <Note>
   In [quota tiers 0 and 1](https://app.blaxel.ai/account/quotas), a maximum TTL is enforced on all sandboxes. On quota tier 2 and above, no expiration policy is set by default.
 </Note>
+
+The sandbox metadata also includes a read-only parameter, `expiresIn`, that computes the number of seconds until a sandbox is terminated due to its TTL or lifecycle policy.
 
 ## Retry strategically in case of errors
 


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Clarifies sandbox expiration documentation by expanding lifecycle policy sub-bullets (`ttl-idle`, `ttl-max-age`, `date`), correcting supported time units to include minutes (`m`), and adding a note about the read-only `expiresIn` metadata field. A follow-up commit fixed a typo.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit eedd4b910200163ac94c7a1a0c876b98a3497f29.</sup>
<!-- /MENDRAL_SUMMARY -->