### PR TITLE
docs: add links for changelog RSS and status page

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -3,6 +3,10 @@ title: 'Changelog'
 description: 'Chronological list of all platform updates, new features, deprecations, and infrastructure changes on Blaxel.'
 ---
 
+<Tip>
+  [Subscribe to this changelog's RSS feed](https://docs.blaxel.ai/changelog/rss.xml) for automated notifications of platform changes and new features.
+</Tip>
+
 <Update label="2026-04-24">
 
 ### New Billing Explorer API

--- a/troubleshooting.mdx
+++ b/troubleshooting.mdx
@@ -5,6 +5,10 @@ description: "Resolve common issues with Blaxel deployments including build fail
 
 This page describes common issues and how to troubleshoot them. If your issue is not covered below, you can also [check our knowledge base](https://support.blaxel.ai).
 
+<Note>
+  For current service status, refer to [https://status.blaxel.ai/](https://status.blaxel.ai/)
+</Note>
+
 ## Preview URLs return a `502 Bad Gateway` server error
 
 This error occurs when the application server is either not running inside the sandbox, or is running but binding to `localhost`. In the latter case, it is only reachable inside the sandbox and the external preview URL will not be able to access it.


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `<Tip>` callout in `changelog.mdx` linking to the RSS feed and a `<Note>` callout in `troubleshooting.mdx` linking to the status page.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c098e0abfa82de02b4aa3a2cd01657865ca6be2d.</sup>
<!-- /MENDRAL_SUMMARY -->