### PR TITLE
docs: update changelog

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -3,11 +3,27 @@ title: 'Changelog'
 description: 'Chronological list of all platform updates, new features, deprecations, and infrastructure changes on Blaxel.'
 ---
 
+<Update label="2026-04-20">
+
+### Cross-account image sharing
+
+Added [image sharing across accounts](/Sandboxes/Templates#share-templates-across-workspaces-and-accounts).
+
+</Update>
+
+<Update label="2026-04-19">
+
+### Rich error messages
+
+Updated platform [error messages](/troubleshooting/error-codes) with additional information, for autonomous use by agents and LLMs.
+
+</Update>
+
 <Update label="2026-04-15">
 
 ### Cross-workspace image sharing
 
-Added [image sharing between workspaces](/Sandboxes/Templates#share-templates-across-workspaces) in the same account.
+Added [image sharing between workspaces](/Sandboxes/Templates#share-templates-across-workspaces-and-accounts) in the same account.
 
 </Update>
 


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds two new changelog entries for 2026-04-19 (rich error messages) and 2026-04-20 (cross-account image sharing), and updates the existing 2026-04-15 entry's anchor link to reflect the renamed section.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d74a2460f747a7430679541d78bb9f7ff26aebd2.</sup>
<!-- /MENDRAL_SUMMARY -->