### PR TITLE
docs: add info on volumes backup

### DIFF
--- a/Volumes/Overview.mdx
+++ b/Volumes/Overview.mdx
@@ -10,6 +10,8 @@ Blaxel Volumes provide **persistent storage that survives resource destruction a
 
 While Blaxel automatically snapshots the full state of a sandbox at scale down and stores it in warm storage for ultra-fast boot times, volumes offer a more cost-effective solution to persist files for weeks to years. Use [volume templates](/Volumes/Volumes-templates) to start from a pre-populated filesystem.
 
+Volumes use block storage which is snapshotted on a daily basis.
+
 ## Create a volume
 
 To create a standalone volume, you must provide a unique `name` and specify its `size` in megabytes (MB). You can also specify optional labels. This volume exists independently of any resource it may later be attached to.


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a single sentence to the Volumes overview documenting that block storage is snapshotted daily.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 1297068c4eaf5eb18af74cb8362387819d4e6fb0.</sup>
<!-- /MENDRAL_SUMMARY -->