### PR TITLE
docs: add info on volume attachment checks

### DIFF
--- a/Sandboxes/Volumes.mdx
+++ b/Sandboxes/Volumes.mdx
@@ -60,6 +60,12 @@ Any files written to the `/app` directory within this sandbox will be stored on 
 
 At this time, you cannot detach a volume from a sandbox.
 
+## Check volume attachment status
+
+Each volume returned from the API includes a `state.attachedTo` field indicating which sandbox the volume is currently attached to.
+
+When a sandbox is deleted, Blaxel automatically clears this field on the volume. You can therefore check `state.attachedTo` directly to determine whether a volume is free to attach to a new sandbox.
+
 <CardGroup cols={2}>
   <Card title="Learn more about volumes" icon="box" href="/Volumes/Overview">
     Learn how to create and manage volumes.


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new section to the Volumes documentation explaining the `state.attachedTo` field and how to use it to check whether a volume is free to attach to a new sandbox.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f85bcefd90bb9078e9c44df5074b215b0932d331.</sup>
<!-- /MENDRAL_SUMMARY -->