### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -3038,6 +3038,26 @@ components:
             type: string
             description: Reason for current status (only set for error status)
             readOnly: true
+    WorkspaceAvailability:
+      type: object
+      description: Result of a workspace-name availability check.
+      properties:
+        available:
+          type: boolean
+          description: Whether the requested workspace name is available.
+        message:
+          type: string
+          description: Human-readable explanation suitable for display in the UI.
+            Empty when available.
+        reason:
+          type: string
+          description: Machine-readable reason explaining why the name is unavailable.
+            Empty when available.
+          enum:
+          - taken
+          - forbidden_reserved
+          - forbidden_blaxel
+          - forbidden_v_prefix
     WorkspaceRuntime:
       type: object
       description: Runtime configuration for the workspace infrastructure
@@ -7869,6 +7889,15 @@ paths:
     post:
       description: Check if a workspace is available.
       operationId: CheckWorkspaceAvailability
+      parameters:
+      - description: When true, return a structured WorkspaceAvailability object with
+          a machine-readable reason and human-readable message instead of a bare boolean.
+          Defaults to false for backwards compatibility.
+        in: query
+        name: withReason
+        required: false
+        schema:
+          type: boolean
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `WorkspaceAvailability` schema component and a `withReason` query parameter to the `CheckWorkspaceAvailability` endpoint, allowing callers to opt into a structured response with machine-readable reason codes and a human-readable message instead of a bare boolean.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4b5c989927e881666579650fe608feb152c2efd5.</sup>
<!-- /MENDRAL_SUMMARY -->