### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -2577,6 +2577,13 @@ components:
           description: Absolute expiration timestamp in ISO 8601 format when the sandbox
             will be deleted
           example: "2025-12-31T23:59:59Z"
+        extraArgs:
+          type: object
+          description: 'Extra arguments for sandbox kernel selection. Supported keys:
+            ''iptables'', ''nvme''. Values: ''enabled'' or ''disabled''. Determines
+            which kernel variant the sandbox runs on. Immutable after creation.'
+          additionalProperties:
+            type: string
         image:
           type: string
           description: Sandbox image to use. Can be a public Blaxel image (e.g., blaxel/base-image:latest)
@@ -3038,6 +3045,26 @@ components:
             type: string
             description: Reason for current status (only set for error status)
             readOnly: true
+    WorkspaceAvailability:
+      type: object
+      description: Result of a workspace-name availability check.
+      properties:
+        available:
+          type: boolean
+          description: Whether the requested workspace name is available.
+        message:
+          type: string
+          description: Human-readable explanation suitable for display in the UI.
+            Empty when available.
+        reason:
+          type: string
+          description: Machine-readable reason explaining why the name is unavailable.
+            Empty when available.
+          enum:
+          - taken
+          - forbidden_reserved
+          - forbidden_blaxel
+          - forbidden_v_prefix
     WorkspaceRuntime:
       type: object
       description: Runtime configuration for the workspace infrastructure
@@ -7869,6 +7896,15 @@ paths:
     post:
       description: Check if a workspace is available.
       operationId: CheckWorkspaceAvailability
+      parameters:
+      - description: When true, return a structured WorkspaceAvailability object with
+          a machine-readable reason and human-readable message instead of a bare boolean.
+          Defaults to false for backwards compatibility.
+        in: query
+        name: withReason
+        required: false
+        schema:
+          type: boolean
       requestBody:
         content:
           application/json:
@@ -7885,7 +7921,9 @@ paths:
           content:
             application/json:
               schema:
-                type: boolean
+                oneOf:
+                - type: boolean
+                - $ref: '#/components/schemas/WorkspaceAvailability'
           description: successful operation
       summary: Check workspace availability
       tags:


### PR DESCRIPTION
Automated update of api docs

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Automated API doc update adding `extraArgs` field to sandbox spec, a new `WorkspaceAvailability` schema, and an opt-in `withReason` query parameter to `CheckWorkspaceAvailability` that returns either a bare boolean or the structured type.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 96264ae9fe23cb36001a079c63b6cee2da0e1cfb.</sup>
<!-- /MENDRAL_SUMMARY -->