### PR TITLE
docs: update region restrictions for proxy and egress gateway

### DIFF
--- a/Infrastructure/Dedicated-egress-gateways.mdx
+++ b/Infrastructure/Dedicated-egress-gateways.mdx
@@ -6,7 +6,6 @@ tag: 'private preview'
 
 <Note>
   This feature is currently in private preview and is not intended for production use. In private preview, it has the following limitations:
-  - It is only available in the `us-was-1` region.
   - It is only available for sandboxes.
   - Egress gateway assignment is only possible at sandbox creation time.
   - Egress gateway removal is only possible by deleting the corresponding sandbox.

--- a/Sandboxes/Proxy-domains.mdx
+++ b/Sandboxes/Proxy-domains.mdx
@@ -5,7 +5,7 @@ tag: "public preview"
 ---
 
 <Note>
-  This feature is currently in public preview and is not recommended for production use. During the preview, the proxy and network features are only available in the `us-was-1` region.
+  This feature is currently in public preview and is not recommended for production use.
 </Note>
 
 Domain filtering lets you control which external domains a sandbox can reach. You can define an allowlist (only listed domains are reachable) or a denylist (all domains except listed ones are reachable). Domain filtering and proxy routing are **independent configurations** — you do not need to duplicate domains across both. A domain can appear in the allowlist without having a proxy routing rule, and vice versa.

--- a/Sandboxes/Proxy-secrets-injection.mdx
+++ b/Sandboxes/Proxy-secrets-injection.mdx
@@ -5,7 +5,7 @@ tag: "public preview"
 ---
 
 <Note>
-  This feature is currently in public preview and is not recommended for production use. During the preview, the proxy and network features are only available in the `us-was-1` region.
+  This feature is currently in public preview and is not recommended for production use.
 </Note>
 
 The Blaxel proxy intercepts outbound HTTPS requests from the sandbox and injects headers, body fields, and secrets server-side.

--- a/Sandboxes/Proxy.mdx
+++ b/Sandboxes/Proxy.mdx
@@ -5,7 +5,7 @@ tag: "public preview"
 ---
 
 <Note>
-  This feature is currently in public preview and is not recommended for production use. During the preview, the proxy and network features are only available in the `us-was-1` region.
+  This feature is currently in public preview and is not recommended for production use.
 </Note>
 
 <span id="proxy-routing"></span>


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the `us-was-1` region restriction from proxy and egress gateway documentation. The region limitation note is removed from three proxy-related pages and from the dedicated egress gateways page.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 412315f02bffbc21ce2755ac279a0dd64441a02d.</sup>
<!-- /MENDRAL_SUMMARY -->