### PR TITLE
docs: add pooling as sandbox best practice

### DIFF
--- a/Sandboxes/best-practices.mdx
+++ b/Sandboxes/best-practices.mdx
@@ -53,6 +53,19 @@ Instead of writing scripts to manually filter and delete sandboxes, use [expirat
 
 The sandbox metadata also includes a read-only parameter, `expiresIn`, that computes the number of seconds until a sandbox is terminated due to its TTL or lifecycle policy.
 
+## Reduce cold start times with a pre-warmed pool
+
+For workloads with heavy images, you can maintain a pool of pre-warmed sandboxes to serve requests with near-zero latency.
+
+The pattern works as follows:
+
+1. Keep a pool of sandboxes ready, with their data recorded in a database or cache.
+2. When a task arrives, assign one sandbox from the pool to that task and mark it as in-use.
+3. After assigning a sandbox, create a replacement in the background to keep the pool at your target size.
+4. When the task finishes, either release the sandbox back to the pool or delete it and let the background replenishment fill the gap.
+
+If using this pattern, implement a queuing system to coordinate sandbox usage and flag which sandboxes are in use. Without this, the same sandbox could be assigned to two tasks arriving at the same instant.
+
 ## Retry strategically in case of errors
 
 Blaxel returns [structured error responses](/troubleshooting/error-codes) in case of sandbox creation or connection failures. To handle these errors, we recommend the following strategy:


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new "Reduce cold start times with a pre-warmed pool" section to the sandbox best practices documentation, describing a pooling pattern with steps for maintaining, assigning, replenishing, and releasing sandboxes, along with a note about needing a queuing system to prevent concurrent assignment.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3fc85fe971b8f21a1790c371893de61421f289d4.</sup>
<!-- /MENDRAL_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
