### PR TITLE
docs: add custom span example

### DIFF
--- a/Observability/Overview.mdx
+++ b/Observability/Overview.mdx
@@ -64,10 +64,12 @@ const span = startSpan("span-name", {
   },
 });
 
-// ... your code here ...
-
-span.setAttribute("action.result", JSON.stringify(result));
-span.end();
+try {
+  // ... your code here ...
+  span.setAttribute("action.result", JSON.stringify(result));
+} finally {
+  span.end();
+}
 ```
 
 ```python Python

--- a/Observability/Overview.mdx
+++ b/Observability/Overview.mdx
@@ -49,6 +49,41 @@ Blaxel collects and saves the traces of a **sampled 10%** of all your executions
 
 ![traces.webp](/Observability/Overview/traces.webp)
 
+#### Add custom spans
+
+You can add your own information to traces, such as inputs, outputs, and intermediate results. This is useful when you need to perform detailed debugging.
+
+<CodeGroup>
+```typescript TypeScript
+import "@blaxel/telemetry";
+import { startSpan } from "@blaxel/telemetry";
+
+const span = startSpan("span-name", {
+  attributes: {
+    "input": JSON.stringify(userInput),
+  },
+});
+
+// ... your code here ...
+
+span.setAttribute("action.result", JSON.stringify(result));
+span.end();
+```
+
+```python Python
+import blaxel.telemetry
+from opentelemetry import trace
+
+tracer = trace.get_tracer(__name__)
+
+with tracer.start_as_current_span("span-name", attributes={"input": user_input}) as span:
+    # ... your code here ...
+    span.set_attribute("action.result", str(result))
+```
+</CodeGroup>
+
+You can call `startSpan` anywhere inside a request handler, and the span will be attached to the active trace for that request.
+
 ## Opt out
 
 This feature is controlled by the `BL_ENABLE_OPENTELEMETRY` environment variable.


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a documentation section to the Observability overview showing how to create custom OpenTelemetry spans in TypeScript and Python, with examples for attaching input/output attributes to traces.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit acb279605e8bce3d77f0933152ed97e32ce886f6.</sup>
<!-- /MENDRAL_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
