### PR TITLE
docs: update troubleshooting for deleted resources

### DIFF
--- a/troubleshooting.mdx
+++ b/troubleshooting.mdx
@@ -158,3 +158,15 @@ module.exports = {
   },
   /// ... rest of webpack/config.dev.js
 ```
+
+## A deleted agent or MCP server still appears in the Blaxel Console listing
+
+This error occurs when a deletion operation didn't fully complete, leaving the resource in a stuck "deleted" state.
+
+To resolve this, run the `bl delete` command again on the same resource:
+
+```bash
+bl delete agent <AGENT-RESOURCE-NAME>
+# or
+bl delete function <MCP-RESOURCE-NAME>
+```


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new troubleshooting section explaining how to resolve stuck "deleted" state for agents and MCP servers by re-running the `bl delete` command.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit cca788f1cd313400e87a58208a0d34d71ba36acb.</sup>
<!-- /MENDRAL_SUMMARY -->