### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -5950,8 +5950,18 @@ paths:
   /sandboxes:
     get:
       description: Returns all sandboxes in the workspace. Each sandbox includes its
-        configuration, status, and endpoint URL.
+        configuration, status, and endpoint URL. Terminated sandboxes are hidden by
+        default; pass `showTerminated=true` to include them.
       operationId: ListSandboxes
+      parameters:
+      - description: If true, include terminated sandboxes in the response. Defaults
+          to false.
+        in: query
+        name: showTerminated
+        required: false
+        schema:
+          default: false
+          type: boolean
       responses:
         "200":
           content:


### PR DESCRIPTION
Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `showTerminated` query parameter to the `GET /sandboxes` endpoint, allowing callers to include terminated sandboxes in the response. The change updates both the endpoint description and the OpenAPI parameter definition.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 21ae4ba885f49e1a35467eff722ab9346380e5b1.</sup>
<!-- /MENDRAL_SUMMARY -->