### PR TITLE
docs: add Docker sandbox tutorial

### DIFF
--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -47,7 +47,7 @@ Blaxel provides a library of pre-built container images for common needs.
 | [`blaxel/lightpanda:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/lightpanda) | Lightweight headless browser |
 | [`blaxel/playwright-chromium:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/playwright-chromium) | Playwright + Chromium browser automation environment with Node.js 20 |
 | [`blaxel/playwright-firefox:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/playwright-firefox) | Playwright + Firefox browser automation environment with Node.js 20 |
-| [`blaxel/docker-in-sandbox:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/docker-in-sandbox) | Docker-in-Docker environment |
+| [`blaxel/docker-in-sandbox:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/docker-in-sandbox) | Docker environment |
 | [`blaxel/xfce-vnc:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/xfce-vnc) | XFCE desktop environment with VNC |
 | [`blaxel/cua-xfce:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/cua-xfce) | XFCE desktop environment with CUA |
 | [`blaxel/jupyter-notebook:latest`](https://github.com/blaxel-ai/sandbox/tree/main/hub/jupyter-notebook) | Jupyter Notebook with Python 3.12 |

--- a/Tutorials/Docker.mdx
+++ b/Tutorials/Docker.mdx
@@ -234,3 +234,5 @@ docker compose up
 ```
 
 <Note>
+  Ensure that your sandbox is configured with sufficient memory for the build process and output.
+</Note>

--- a/Tutorials/Docker.mdx
+++ b/Tutorials/Docker.mdx
@@ -226,7 +226,7 @@ docker run ttl.sh/my-app:1h
 
 ## Use Docker Compose
 
-The Docker sandbox image includes a sample application with a Docker Compose file, in the `example` directory. Try it with the following commands:
+The Docker sandbox image includes a sample Docker Compose application in the `example` directory. Try it with the following commands:
 
 ```shell
 cd example

--- a/Tutorials/Docker.mdx
+++ b/Tutorials/Docker.mdx
@@ -1,0 +1,212 @@
+---
+title: 'Run Docker in a sandbox'
+description: 'Build, push and run Docker images in a Blaxel sandbox'
+---
+
+This tutorial explains how to build and push Docker images inside a Blaxel sandbox. It also explains how to run Docker containers and expose them securely using sandbox preview URLs.
+
+## Prerequisites
+
+- [Blaxel CLI](../cli-reference/introduction) installed and authenticated (`bl login`)
+- Node.js 18+ or Python 3.12+ installed
+- Blaxel SDK installed in your project (`npm install @blaxel/core` or `pip install blaxel`)
+
+## Create and connect to a sandbox
+
+Blaxel provides a ready-to-use sandbox image (`blaxel/docker-in-sandbox`) with everything you need to build and run Docker images. This image also includes the Docker CLI, Docker Compose and `iptables-legacy` (as a replacement for `nftables`).
+
+Create and deploy a sandbox using the Docker sandbox image:
+
+<CodeGroup>
+
+```shell Blaxel CLI
+bl apply -f - <<EOF
+apiVersion: blaxel.ai/v1alpha1
+kind: Sandbox
+metadata:
+  name: my-docker-sandbox
+spec:
+  runtime:
+    region: us-pdx-1
+    image: blaxel/docker-in-sandbox:latest
+    generation: mk3
+    memory: 4096
+EOF
+```
+
+```typescript TypeScript
+import { SandboxInstance } from "@blaxel/core";
+
+const sandbox = await SandboxInstance.create({
+  name: "my-docker-sandbox",
+  image: "blaxel/docker-in-sandbox:latest",
+  memory: 4096,
+  region: "us-pdx-1"
+});
+```
+
+```python Python
+from blaxel.core import SandboxInstance
+
+sandbox = await SandboxInstance.create({
+    "name": "my-docker-sandbox",
+    "image": "blaxel/docker-in-sandbox:latest",
+    "memory": 4096,
+    "region": "us-pdx-1"
+})
+```
+
+</CodeGroup>
+
+Connect to the sandbox terminal for subsequent commands:
+
+```shell
+bl connect sandbox my-docker-sandbox
+```
+
+## Run a Docker container
+
+You can run a container from any public image. Here is an example of running an NGINX container:
+
+```shell
+docker run -d -p 8081:80 --name my-nginx nginx
+```
+
+Check that it is running:
+
+```shell
+docker ps
+```
+
+## Open a shell into a running Docker container
+
+Use `docker exec` to open a shell inside the running container:
+
+```shell
+docker exec -it my-nginx /bin/sh
+```
+
+## Expose a Docker container at a sandbox preview URL
+
+Once a Docker container is running inside your sandbox, you can expose it externally via a [preview URL](/Sandboxes/Preview-url).
+
+To see this in action, run an NGINX container on sandbox port 8081:
+
+```shell
+docker run -d -p 8081:80 nginx
+```
+
+Then, use the Blaxel SDK to create a preview URL for that port:
+
+<CodeGroup>
+
+```typescript TypeScript
+import { SandboxInstance } from "@blaxel/core";
+
+const sandbox = await SandboxInstance.get("my-docker-sandbox");
+
+const preview = await sandbox.previews.create({
+    metadata: { name: "nginx-preview" },
+    spec: {
+        port: 8081,
+        public: true
+    }
+});
+
+console.log("Preview URL:", preview.spec?.url);
+```
+
+```python Python
+from blaxel.core import SandboxInstance
+
+sandbox = await SandboxInstance.get("my-docker-sandbox")
+
+preview = await sandbox.previews.create({
+    "metadata": {"name": "nginx-preview"},
+    "spec": {
+        "port": 8081,
+        "public": True
+    }
+})
+
+print("Preview URL:", preview.spec.url)
+```
+
+</CodeGroup>
+
+Now, when you access the preview URL, you should see the default NGINX welcome page.
+
+<Tip>
+  To restrict access, you can create a [private preview URL](/Sandboxes/Preview-url/#private-preview-urls) instead.
+</Tip>
+
+## Build and push a Docker image
+
+You can also build and push images from the sandbox.
+
+To see this in action, first create a minimal `Dockerfile` in the sandbox's `/app` directory:
+
+```Dockerfile
+FROM alpine:latest
+CMD ["echo", "Hello from Blaxel"]
+```
+
+Then, build and push it to [ttl.sh](https://ttl.sh), a transient registry:
+
+<Note>
+  If you plan to run the final image on a Blaxel sandbox, add the `--platform linux/amd64` when building so the image runs correctly.
+</Note>
+
+<CodeGroup>
+
+```shell Blaxel CLI
+cd /app
+docker build --platform linux/amd64 -t ttl.sh/my-app:1h .
+docker push ttl.sh/my-app:1h
+```
+
+```typescript TypeScript
+import { SandboxInstance } from "@blaxel/core";
+
+const sandbox = await SandboxInstance.get("my-docker-sandbox");
+const image = "ttl.sh/my-app:1h";
+
+const build = await sandbox.process.exec({
+  command: `docker build --platform linux/amd64 -t ${image} /app`,
+  waitForCompletion: true,
+});
+console.log(build.logs);
+
+const push = await sandbox.process.exec({
+  command: `docker push ${image}`,
+  waitForCompletion: true,
+});
+console.log(push.logs);
+```
+
+```python Python
+from blaxel.core import SandboxInstance
+
+sandbox = await SandboxInstance.get("my-docker-sandbox")
+image = "ttl.sh/my-app:1h"
+
+build = await sandbox.process.exec({
+    "command": f"docker build --platform linux/amd64 -t {image} /app",
+    "wait_for_completion": True,
+})
+print(build.logs)
+
+push = await sandbox.process.exec({
+    "command": f"docker push {image}",
+    "wait_for_completion": True,
+})
+print(push.logs)
+```
+
+</CodeGroup>
+
+Once the image is published to the registry, you can test it with `docker run`:
+
+```shell
+docker run ttl.sh/my-app:1h
+```

--- a/Tutorials/Docker.mdx
+++ b/Tutorials/Docker.mdx
@@ -46,14 +46,18 @@ const sandbox = await SandboxInstance.create({
 ```
 
 ```python Python
+import asyncio
 from blaxel.core import SandboxInstance
 
-sandbox = await SandboxInstance.create({
-    "name": "my-docker-sandbox",
-    "image": "blaxel/docker-in-sandbox:latest",
-    "memory": 4096,
-    "region": "us-pdx-1"
-})
+async def main():
+    sandbox = await SandboxInstance.create({
+        "name": "my-docker-sandbox",
+        "image": "blaxel/docker-in-sandbox:latest",
+        "memory": 4096,
+        "region": "us-pdx-1"
+    })
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 </CodeGroup>
@@ -117,19 +121,23 @@ console.log("Preview URL:", preview.spec?.url);
 ```
 
 ```python Python
+import asyncio
 from blaxel.core import SandboxInstance
 
-sandbox = await SandboxInstance.get("my-docker-sandbox")
+async def main():
+    sandbox = await SandboxInstance.get("my-docker-sandbox")
 
-preview = await sandbox.previews.create({
-    "metadata": {"name": "nginx-preview"},
-    "spec": {
-        "port": 8081,
-        "public": True
-    }
-})
+    preview = await sandbox.previews.create({
+        "metadata": {"name": "nginx-preview"},
+        "spec": {
+            "port": 8081,
+            "public": True
+        }
+    })
 
-print("Preview URL:", preview.spec.url)
+    print("Preview URL:", preview.spec.url)
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 </CodeGroup>
@@ -151,7 +159,7 @@ FROM alpine:latest
 CMD ["echo", "Hello from Blaxel"]
 ```
 
-Then, build and push it to [ttl.sh](https://ttl.sh), a transient registry:
+Then, build and push it to [ttl.sh](https://ttl.sh), a transient image registry:
 
 <Note>
   If you plan to run the final image on a Blaxel sandbox, add the `--platform linux/amd64` when building so the image runs correctly.
@@ -185,22 +193,27 @@ console.log(push.logs);
 ```
 
 ```python Python
+import asyncio
 from blaxel.core import SandboxInstance
 
-sandbox = await SandboxInstance.get("my-docker-sandbox")
-image = "ttl.sh/my-app:1h"
+async def main():
+    sandbox = await SandboxInstance.get("my-docker-sandbox")
+    image = "ttl.sh/my-app:1h"
 
-build = await sandbox.process.exec({
-    "command": f"docker build --platform linux/amd64 -t {image} /app",
-    "wait_for_completion": True,
-})
-print(build.logs)
+    build = await sandbox.process.exec({
+        "command": f"docker build --platform linux/amd64 -t {image} /app",
+        "wait_for_completion": True,
+    })
+    print(build.logs)
 
-push = await sandbox.process.exec({
-    "command": f"docker push {image}",
-    "wait_for_completion": True,
-})
-print(push.logs)
+    push = await sandbox.process.exec({
+        "command": f"docker push {image}",
+        "wait_for_completion": True,
+    })
+    print(push.logs)
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 </CodeGroup>
@@ -210,3 +223,14 @@ Once the image is published to the registry, you can test it with `docker run`:
 ```shell
 docker run ttl.sh/my-app:1h
 ```
+
+## Use Docker Compose
+
+The Docker sandbox image includes a sample application with a Docker Compose file, in the `example` directory. Try it with the following commands:
+
+```shell
+cd example
+docker compose up
+```
+
+<Note>

--- a/Tutorials/Docker.mdx
+++ b/Tutorials/Docker.mdx
@@ -27,10 +27,10 @@ metadata:
   name: my-docker-sandbox
 spec:
   runtime:
-    region: us-pdx-1
     image: blaxel/docker-in-sandbox:latest
     generation: mk3
     memory: 4096
+  region: us-pdx-1
 EOF
 ```
 

--- a/Tutorials/Docker.mdx
+++ b/Tutorials/Docker.mdx
@@ -136,8 +136,12 @@ async def main():
     })
 
     print("Preview URL:", preview.spec.url)
+
+    print("Preview URL:", preview.spec.url)
+
 if __name__ == "__main__":
     asyncio.run(main())
+
 ```
 
 </CodeGroup>

--- a/Tutorials/Docker.mdx
+++ b/Tutorials/Docker.mdx
@@ -55,7 +55,7 @@ async def main():
         "image": "blaxel/docker-in-sandbox:latest",
         "memory": 4096,
         "region": "us-pdx-1"
-    })
+
 if __name__ == "__main__":
     asyncio.run(main())
 ```

--- a/Tutorials/Docker.mdx
+++ b/Tutorials/Docker.mdx
@@ -135,12 +135,12 @@ async def main():
         }
     })
 
-    print("Preview URL:", preview.spec.url)
 
     print("Preview URL:", preview.spec.url)
 
 if __name__ == "__main__":
     asyncio.run(main())
+
 
 ```
 

--- a/Tutorials/Docker.mdx
+++ b/Tutorials/Docker.mdx
@@ -162,7 +162,7 @@ CMD ["echo", "Hello from Blaxel"]
 Then, build and push it to [ttl.sh](https://ttl.sh), a transient image registry:
 
 <Note>
-  If you plan to run the final image on a Blaxel sandbox, add the `--platform linux/amd64` when building so the image runs correctly.
+  If you plan to run the final image on a Blaxel sandbox, add the `--platform linux/amd64` flag when building so the image runs correctly.
 </Note>
 
 <CodeGroup>

--- a/Tutorials/Sandboxes-Overview.mdx
+++ b/Tutorials/Sandboxes-Overview.mdx
@@ -15,6 +15,12 @@ Blaxel lets you run Web applications inside a Blaxel sandbox and preview the con
   <Card title="Next.js" href="/Tutorials/Nextjs">
     Run Next.js in a sandbox.
   </Card>
+  <Card title="Code-server" href="/Tutorials/Code-server">
+    Run code-server in a sandbox.
+  </Card>
+  <Card title="Docker" href="/Tutorials/Docker">
+    Run Docker in a sandbox.
+  </Card>
   <Card title="Tailscale" href="/Tutorials/Tailscale">
     Run Tailscale in a sandbox.
   </Card>

--- a/docs.json
+++ b/docs.json
@@ -277,11 +277,8 @@
               "Tutorials/Expo",
               "Tutorials/Nextjs",
               "Tutorials/Code-server",
-<<<<<<< HEAD
+              "Tutorials/Docker",
               "Tutorials/Tailscale"
-=======
-              "Tutorials/Docker"
->>>>>>> d57413e (docs: add Docker sandbox tutorial)
             ]
           },
           {

--- a/docs.json
+++ b/docs.json
@@ -277,7 +277,11 @@
               "Tutorials/Expo",
               "Tutorials/Nextjs",
               "Tutorials/Code-server",
+<<<<<<< HEAD
               "Tutorials/Tailscale"
+=======
+              "Tutorials/Docker"
+>>>>>>> d57413e (docs: add Docker sandbox tutorial)
             ]
           },
           {


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new Docker sandbox tutorial covering sandbox creation, running containers, exposing them via preview URLs, building/pushing images, and using Docker Compose. Registers the page in `docs.json` and `Sandboxes-Overview.mdx`, and updates the `blaxel/docker-in-sandbox` template description.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 07b54fdcb2bdc0b9a59ec9783ad64230f42db128.</sup>
<!-- /MENDRAL_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
