### PR TITLE
docs: clarify various items 

### DIFF
--- a/Model-Governance/Environments.mdx
+++ b/Model-Governance/Environments.mdx
@@ -35,9 +35,7 @@ For example, let’s say you attach the following three policies on environment 
 
 - US only: Country is United States *(type of policy: location)*
 - Asia only: Continent is Asia *(type of policy: location)*
-- T4 only: GPU is T4 *(type of policy: gpu)*
-
-Then, all workloads deployed in ‘development’ will run **necessarily on T4 accelerators**, which are on **any** location that is either in the US or in any country in Asia. 
+Then, all workloads deployed in ‘development’ will run on **any** location that is either in the US or in any country in Asia. 
 
 ## **Deploying workloads to an environment**
 

--- a/Model-Governance/Overview.mdx
+++ b/Model-Governance/Overview.mdx
@@ -20,7 +20,7 @@ Read more about environments.
 
 ## Policies
 
-Policies in Blaxel provide a way to control how and where models are deployed. They enforce rules on execution, such as geographic restrictions or GPU requirements, ensuring compliance with organizational guidelines. Policies can be applied at the environment level or to specific model deployments, allowing for flexible, targeted control.
+Policies in Blaxel provide a way to control how and where models are deployed. They enforce rules on execution, such as geographic restrictions or hardware requirements, ensuring compliance with organizational guidelines. Policies can be applied at the environment level or to specific model deployments, allowing for flexible, targeted control.
 
 <Card title="Policies" icon="file-circle-check" href="/Model-Governance/Policies">
 Read more about policies.

--- a/Model-Governance/Policies.mdx
+++ b/Model-Governance/Policies.mdx
@@ -41,15 +41,12 @@ They come in two different formats:
 
 ### Flavor policies
 
-Flavor policies give control over which underlying accelerator (GPU) your workloads will be executed on. 
+Flavor policies give control over which underlying hardware your workloads will be executed on.
 
 They come in two different formats:
 
 - policies on **cpu** allow to pass a specific list of CPU types
     - for example, execute only on x86
-- policies on **gpu** allow to pass a specific list of GPU types
-    - execute only on NVIDIA A100
-    - execute only on NVIDIA L4 or NVIDIA T4
 
 ### Token usage policies
 
@@ -82,12 +79,8 @@ For example:
 - Let’s assume the following policies:
     - Policy A: Country is: USA
     - Policy B: Continent is: North America, or Europe
-    - Policy C: GPU is: NVIDIA T4
 - if a workload has the following combined policies:
     - A and B: then the workload will only execute in any location in either North America (including USA) or Europe — on any kind of hardware available there.
-    - B and C: then the workload will only execute in any location in either North America or Europe, only on T4 GPUs.
-    - A and C: then the workload will only execute in any location in the USA, only on T4 GPUs.
-    - A and B and C: then the workload will only execute in any location in either North America (including USA) or Europe — only on T4 GPUs.
 
 ## Policy reference
 
@@ -100,7 +93,6 @@ Below is the list of official names to build policies.
 | **Code** | **Type** | **Flavor Name** |
 | --- | --- | --- |
 | CPU x86 | cpu | x86 |
-| t4 | gpu | NVIDIA T4 |
 
 ### Locations
 

--- a/Models/Model-deployment.mdx
+++ b/Models/Model-deployment.mdx
@@ -117,15 +117,11 @@ You must choose an [environment](../Model-Governance/Environments) when deployin
 
 Additional [policies](../Model-Governance/Policies) can be optionally attached to a model deployment directly. If there already are policies set in the environment, policies of the **same policy type** (e.g. location-based, flavor-based, etc.) will collide. In this case, the result will be [as described here](../Model-Governance/Policies).
 
-<Tip>To force execution of the model on a certain type of GPU, it is best to configure it in the model deployment [resources](/Models/Model-deployment) directly.</Tip>
-
 ### Resources
 
-Data scientists often have strong preferences for specific GPU types when running certain models. To accommodate this, Blaxel allows you to specify which flavors (i.e., which GPU types) should be used for running a particular model.
+Blaxel allows you to specify which flavors (i.e., which CPU types) should be used for running a particular model.
 
-Flavors refer to the specific CPU or GPU types that the model deployment will use for processing inferences. During inferences execution, the Global Inference Network intelligently routes each request to a location containing the desired CPU/GPU types. It then schedules the workload based on resource availability, ensuring optimal performance.
-
-For one model deployment, the selected flavors can either be several CPU types, or several GPU types, but not both at the same time.
+Flavors refer to the specific CPU types that the model deployment will use for processing inferences. During inference execution, the Global Inference Network intelligently routes each request to a location containing the desired CPU types. It then schedules the workload based on resource availability, ensuring optimal performance.
 
 <Note>You can only select flavors allowed by the policies set in the environment or the deployment.</Note>
 

--- a/Sandboxes/Filesystem.mdx
+++ b/Sandboxes/Filesystem.mdx
@@ -30,6 +30,8 @@ export BL_WORKSPACE=my-workspace
 export BL_API_KEY=my-api-key
 ```
 
+The Blaxel SDK does not accept credentials as constructor arguments. Credentials must come from environment variables, a `.env` file, or a local CLI login session (see below).
+
 When developing locally, you can also **log in to your workspace with Blaxel CLI** (as shown above). This allows you to run Blaxel SDK functions that will automatically connect to your workspace without additional setup. When you deploy on Blaxel, authentication is handled automatically — no environment variables needed.
 
 </Accordion>

--- a/Sandboxes/Log-streaming.mdx
+++ b/Sandboxes/Log-streaming.mdx
@@ -28,6 +28,8 @@ export BL_WORKSPACE=my-workspace
 export BL_API_KEY=my-api-key
 ```
 
+The Blaxel SDK does not accept credentials as constructor arguments. Credentials must come from environment variables, a `.env` file, or a local CLI login session (see below).
+
 When developing locally, you can also **log in to your workspace with Blaxel CLI** (as shown above). This allows you to run Blaxel SDK functions that will automatically connect to your workspace without additional setup. When you deploy on Blaxel, authentication is handled automatically — no environment variables needed.
 
 </Accordion>

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -32,7 +32,7 @@ Unlike traditional sandbox infrastructure, Blaxel's standout feature is fully ma
 
 Sandboxes stay in active mode as long as there's an active connection to them.
 
-You are charged for memory (based on how much you allocated at sandbox creation) and storage while a sandbox is in active mode. CPU resources are allocated accordingly by Blaxel based on your selected memory allocation and are not charged separately. For example, a sandbox with 8 GB memory is allocated 4 CPU cores, while one with 16 GB memory is allocated 8 CPU cores. [Learn more about pricing](https://blaxel.ai/pricing).
+You are charged for memory (based on how much you allocated at sandbox creation) and storage while a sandbox is in active mode. CPU resources are allocated accordingly by Blaxel based on your selected memory allocation and are not charged separately. For example, a sandbox with 8 GB memory is allocated 4 CPU cores, while one with 16 GB memory is allocated 6 CPU cores. [Learn more about pricing](https://blaxel.ai/pricing).
 
 ### Standby mode
 

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -107,6 +107,8 @@ export BL_WORKSPACE=my-workspace
 export BL_API_KEY=my-api-key
 ```
 
+The Blaxel SDK does not accept credentials as constructor arguments. Credentials must come from environment variables, a `.env` file, or a local CLI login session (see below).
+
 When developing locally, you can also **log in to your workspace with Blaxel CLI** (as shown above). This allows you to run Blaxel SDK functions that will automatically connect to your workspace without additional setup. When you deploy on Blaxel, authentication is handled automatically — no environment variables needed.
 
 </Accordion>

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -32,7 +32,7 @@ Unlike traditional sandbox infrastructure, Blaxel's standout feature is fully ma
 
 Sandboxes stay in active mode as long as there's an active connection to them.
 
-You are charged for memory (based on how much you allocated at sandbox creation) and storage while a sandbox is in active mode. CPU resources are allocated accordingly by Blaxel based on your selected memory allocation and are not charged separately. [Learn more about pricing](https://blaxel.ai/pricing).
+You are charged for memory (based on how much you allocated at sandbox creation) and storage while a sandbox is in active mode. CPU resources are allocated accordingly by Blaxel based on your selected memory allocation and are not charged separately. For example, a sandbox with 8 GB memory is allocated 4 CPU cores, while one with 16 GB memory is allocated 8 CPU cores. [Learn more about pricing](https://blaxel.ai/pricing).
 
 ### Standby mode
 

--- a/Sandboxes/Preview-url.mdx
+++ b/Sandboxes/Preview-url.mdx
@@ -90,6 +90,8 @@ export BL_WORKSPACE=my-workspace
 export BL_API_KEY=my-api-key
 ```
 
+The Blaxel SDK does not accept credentials as constructor arguments. Credentials must come from environment variables, a `.env` file, or a local CLI login session (see below).
+
 When developing locally, you can also **log in to your workspace with Blaxel CLI** (as shown above). This allows you to run Blaxel SDK functions that will automatically connect to your workspace without additional setup. When you deploy on Blaxel, authentication is handled automatically — no environment variables needed.
 
 </Accordion>

--- a/Sandboxes/Processes.mdx
+++ b/Sandboxes/Processes.mdx
@@ -30,6 +30,8 @@ export BL_WORKSPACE=my-workspace
 export BL_API_KEY=my-api-key
 ```
 
+The Blaxel SDK does not accept credentials as constructor arguments. Credentials must come from environment variables, a `.env` file, or a local CLI login session (see below).
+
 When developing locally, you can also **log in to your workspace with Blaxel CLI** (as shown above). This allows you to run Blaxel SDK functions that will automatically connect to your workspace without additional setup. When you deploy on Blaxel, authentication is handled automatically — no environment variables needed.
 
 </Accordion>

--- a/Volumes/Overview.mdx
+++ b/Volumes/Overview.mdx
@@ -10,6 +10,8 @@ Blaxel Volumes provide **persistent storage that survives resource destruction a
 
 While Blaxel automatically snapshots the full state of a sandbox at scale down and stores it in warm storage for ultra-fast boot times, volumes offer a more cost-effective solution to persist files for weeks to years. Use [volume templates](/Volumes/Volumes-templates) to start from a pre-populated filesystem.
 
+Volumes use block storage and can only be accessed by attaching them to a running sandbox or agent. They cannot be mounted locally on your machine. Blaxel also does not support mounting external storage (such as S3 buckets) as volumes.
+
 ## Create a volume
 
 To create a standalone volume, you must provide a unique `name` and specify its `size` in megabytes (MB). You can also specify optional labels. This volume exists independently of any resource it may later be attached to.

--- a/sdk-reference/introduction.mdx
+++ b/sdk-reference/introduction.mdx
@@ -46,7 +46,7 @@ Or add them to a `.env` file at the root of your project.
 
 ## How authentication works
 
-The Blaxel SDK authenticates with your workspace using credentials from these sources, in priority order:
+The Blaxel SDK does not accept credentials as constructor arguments. Credentials must be supplied through one of the following sources, checked in priority order:
 
 1. when running on Blaxel, authentication is handled automatically
 2. `BL_WORKSPACE` and `BL_API_KEY` environment variables or `.env` file (see [this page](../Agents/Variables-and-secrets) for other authentication options)

--- a/troubleshooting.mdx
+++ b/troubleshooting.mdx
@@ -106,7 +106,7 @@ To resolve this error, you have two options:
     <Note>
     Increasing memory also increases CPU allocation
     - 8GB memory = 4 CPU cores
-    - 16GB memory = 8 CPU cores
+    - 16GB memory = 6 CPU cores
     </Note>
 
 - Add storage using [volumes](/Sandboxes/Volumes). Adding storage requires deleting and recreating the sandbox first.


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Documentation-only PR that removes GPU/T4 references, clarifies SDK authentication (no constructor args), adds volume storage constraints, and corrects the RAM/vCPU mapping for 16 GB sandboxes from 8 to 6 cores.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 1b7690aa39ab6bac4a40fcfd8c62572f282a1679.</sup>
<!-- /MENDRAL_SUMMARY -->