### PR TITLE
fix: add missing info for process logs

### DIFF
--- a/Sandboxes/Log-streaming.mdx
+++ b/Sandboxes/Log-streaming.mdx
@@ -70,6 +70,10 @@ print(process.logs)
 
 </CodeGroup>
 
+Process execution logs are also visible in the Blaxel Console. Refer to the **Logs** section of the sandbox detail page, as shown below:
+
+![process logs](/images/sandboxes/process-logs.webp)
+
 ### Retrieve from a completed process name or ID
 
 Retrieve logs for a specific [process](/Sandboxes/Processes) (using either its name or process ID) after it has completed execution. By default, this retrieves standard output (**stdout**) only:


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a note and screenshot reference directing users to view process execution logs in the Blaxel Console, inserted between the code examples and the "Retrieve from a completed process" section.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 73ec783a5a60eee19f31a4dc8669c8e6272d2ff8.</sup>
<!-- /MENDRAL_SUMMARY -->