### PR TITLE
docs: update for external connections

### DIFF
--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -44,6 +44,10 @@ When transitioning to standby mode, Blaxel automatically creates a snapshot of t
 
 Reconnecting to the sandbox transitions it back to active mode. Any running processes are included in this snapshot and will be instantly restored when you reconnect to the sandbox.
 
+<Warning>
+  The snapshot preserves process and filesystem state, but not external network connections, such as database connections, message queues, or HTTP connection pools, which will automatically time out and close on the remote side of the connection.
+</Warning>
+
 You are not charged for memory while a sandbox is in standby mode. However, you are charged for the storage of the snapshot and/or the volumes. [Learn more about pricing](https://blaxel.ai/pricing).
 
 <Note>

--- a/Sandboxes/best-practices.mdx
+++ b/Sandboxes/best-practices.mdx
@@ -43,7 +43,7 @@ Here's a table to help you decide:
 
 ## Automate cleanup with TTLs
 
-While we advocate for treating sandboxes as perpetual computers, not every machine needs to last forever. In production, you will inevitably accumulate a long tail of sandboxes that will never be called upon again (e.g., completed tasks, abandoned user sessions). To prevent digital clutter and unnecessary storage usage, you need automated garbage collection.
+In production, you will inevitably accumulate a long tail of sandboxes that will never be called upon again (completed tasks, abandoned user sessions, etc.). These can unnecessarily consume storage and add to your cost.
 
 Instead of writing scripts to manually filter and delete sandboxes, use [expiration parameters and lifecycle policies](../Sandboxes/Expiration) to automate when a sandbox should be retired. You can configure this based on idle duration (_e.g., delete if it hasn't been active for 7 days_) or absolute maximum age (_e.g., delete after 30 days_).
 
@@ -73,6 +73,14 @@ When creating sandboxes and preview URLs, use `createIfNotExists()` (TypeScript)
 These methods are idempotent and handle conflicts gracefully when the requested resource already exists. If it exists, they return it; if not, they create it.
 
 You should use `create()` only if you explicitly want an error to be raised when a sandbox or preview URL with the specified name already exists.
+
+## Reconnect external connections after standby
+
+When transitioning to standby mode, Blaxel automatically creates a snapshot of the entire state (including the complete file system in memory, preserving both files and running processes).
+
+However, external network connections that were active at the time of transitioning to standby, such as database connections, message queues, and HTTP connection pools, are not preserved; the remote side will automatically time out and close. When the sandbox resumes, the sandbox side of the connection will be stale, and queries or commands using it will fail.
+
+The recommended approach in this case is to use the connection library's built-in health-check or reconnection option to check or reset a connection before using it. For example, you could configure `pool_pre_ping` (SQLAlchemy) for PostgreSQL/MySQL connections, or `retryStrategy` (ioredis) for Redis connections.
 
 ## Retry strategically in case of errors
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `<Warning>` callout in the Overview page and a new best-practices section clarifying that external network connections (DB, message queues, HTTP pools) are not preserved across sandbox standby snapshots, with reconnection guidance (e.g., `pool_pre_ping`, `retryStrategy`). Also trims an opinionated sentence in the TTL section.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0c390568874197e6ba124dee5a1b158bf698102a.</sup>
<!-- /MENDRAL_SUMMARY -->