### PR TITLE
docs: update link to help center

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -231,7 +231,7 @@
             "pages": [
               "troubleshooting",
               "troubleshooting/error-codes",
-              "troubleshooting/knowledge-base"
+              "troubleshooting/help-center"
             ]
           }
         ]

--- a/troubleshooting/help-center.mdx
+++ b/troubleshooting/help-center.mdx
@@ -1,4 +1,4 @@
 ---
-title: "Knowledge base"
+title: "Help center"
 url: "https://support.blaxel.ai"
 ---


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Renames the troubleshooting page from "Knowledge base" to "Help center" by renaming the MDX file and updating the docs.json navigation reference accordingly.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8ffea8948947e2a717eea8ea0bb325ae302be3c7.</sup>
<!-- /MENDRAL_SUMMARY -->