### PR TITLE
docs: add section for build variables

### DIFF
--- a/Agents/Variables-and-secrets.mdx
+++ b/Agents/Variables-and-secrets.mdx
@@ -27,7 +27,6 @@ You can then use secrets in your code as follows:
 
 import { env } from "@blaxel/core";
 console.info(env.MY_SECRET); // 123456
-
 ```
 
 ```python Python

--- a/Agents/Variables-and-secrets.mdx
+++ b/Agents/Variables-and-secrets.mdx
@@ -89,6 +89,40 @@ os.environ.get('DEFAULT_CITY')
 
 </CodeGroup>
 
+## Build variables
+
+Build variables let you pass secrets and configuration values into the Docker build phase without exposing them at runtime. This is useful when your build process needs credentials that should never appear inside the deployed agent.
+
+Two options exist: `.env.build` for build secrets and `blaxel.toml` file for non-secret build variables.
+
+### .env.build
+
+Create a `.env.build` file in the root of your project for build secrets. A common example of this is installing private npm packages, which require an `NPM_TOKEN` during `npm install`. Variables defined here are injected during the build phase only and are never persisted in the runtime environment.
+
+```bash .env.build
+MY_SECRET_BUILD_VAR=I_AM_A_SECRET
+```
+
+<Tip>
+  Use the `--build-env-file` argument to `bl deploy` to specify a custom file name or path instead of the default `.env.build`.
+</Tip>
+
+<Warning>
+  Ensure that `.env.build` is ignored during commits to avoid accidentally making secrets public.
+</Warning>
+
+### blaxel.toml
+
+Non-secret build variables that can be placed in the `blaxel.toml` file, as in the example below:
+
+```toml blaxel.toml
+type = "agent"
+name = "my-agent"
+
+[build.args]
+MY_BUILD_VAR = "I_AM_NOT_A_SECRET"
+```
+
 ## Reserved variables
 
 The following variables are reserved by Blaxel:

--- a/Functions/Variables-and-secrets.mdx
+++ b/Functions/Variables-and-secrets.mdx
@@ -121,6 +121,7 @@ name = "my-function"
 
 [build.args]
 MY_BUILD_VAR = "I_AM_NOT_A_SECRET"
+```
 
 ## Reserved variables
 

--- a/Functions/Variables-and-secrets.mdx
+++ b/Functions/Variables-and-secrets.mdx
@@ -89,6 +89,40 @@ os.environ.get('DEFAULT_CITY')
 
 </CodeGroup>
 
+## Build variables
+
+Build variables let you pass secrets and configuration values into the Docker build phase without exposing them at runtime. This is useful when your build process needs credentials that should never appear inside the deployed MCP server.
+
+Two options exist: `.env.build` for build secrets and `blaxel.toml` file for non-secret build variables.
+
+### .env.build
+
+Create a `.env.build` file in the root of your project for build secrets. A common example of this is installing private npm packages, which require an `NPM_TOKEN` during `npm install`. Variables defined here are injected during the build phase only and are never persisted in the runtime environment.
+
+```bash .env.build
+MY_SECRET_BUILD_VAR=I_AM_A_SECRET
+```
+
+<Tip>
+  Use the `--build-env-file` argument to `bl deploy` to specify a custom file name or path instead of the default `.env.build`.
+</Tip>
+
+<Warning>
+  Ensure that `.env.build` is ignored during commits to avoid accidentally making secrets public.
+</Warning>
+
+### blaxel.toml
+
+Non-secret build variables that can be placed in the `blaxel.toml` file, as in the example below:
+
+```toml blaxel.toml
+type = "agent"
+name = "my-agent"
+
+[build.args]
+MY_BUILD_VAR = "I_AM_NOT_A_SECRET"
+```
+
 ## Reserved variables
 
 The following variables are reserved by Blaxel:

--- a/Functions/Variables-and-secrets.mdx
+++ b/Functions/Variables-and-secrets.mdx
@@ -116,12 +116,11 @@ MY_SECRET_BUILD_VAR=I_AM_A_SECRET
 Non-secret build variables that can be placed in the `blaxel.toml` file, as in the example below:
 
 ```toml blaxel.toml
-type = "agent"
-name = "my-agent"
+type = "function"
+name = "my-function"
 
 [build.args]
 MY_BUILD_VAR = "I_AM_NOT_A_SECRET"
-```
 
 ## Reserved variables
 

--- a/Jobs/Variables-and-secrets-jobs.mdx
+++ b/Jobs/Variables-and-secrets-jobs.mdx
@@ -121,6 +121,7 @@ name = "my-job"
 
 [build.args]
 MY_BUILD_VAR = "I_AM_NOT_A_SECRET"
+```
 
 ## Reserved variables
 

--- a/Jobs/Variables-and-secrets-jobs.mdx
+++ b/Jobs/Variables-and-secrets-jobs.mdx
@@ -116,12 +116,11 @@ MY_SECRET_BUILD_VAR=I_AM_A_SECRET
 Non-secret build variables that can be placed in the `blaxel.toml` file, as in the example below:
 
 ```toml blaxel.toml
-type = "agent"
-name = "my-agent"
+type = "job"
+name = "my-job"
 
 [build.args]
 MY_BUILD_VAR = "I_AM_NOT_A_SECRET"
-```
 
 ## Reserved variables
 

--- a/Jobs/Variables-and-secrets-jobs.mdx
+++ b/Jobs/Variables-and-secrets-jobs.mdx
@@ -89,6 +89,40 @@ os.environ.get('DEFAULT_CITY')
 
 </CodeGroup>
 
+## Build variables
+
+Build variables let you pass secrets and configuration values into the Docker build phase without exposing them at runtime. This is useful when your build process needs credentials that should never appear inside the deployed job.
+
+Two options exist: `.env.build` for build secrets and `blaxel.toml` file for non-secret build variables.
+
+### .env.build
+
+Create a `.env.build` file in the root of your project for build secrets. A common example of this is installing private npm packages, which require an `NPM_TOKEN` during `npm install`. Variables defined here are injected during the build phase only and are never persisted in the runtime environment.
+
+```bash .env.build
+MY_SECRET_BUILD_VAR=I_AM_A_SECRET
+```
+
+<Tip>
+  Use the `--build-env-file` argument to `bl deploy` to specify a custom file name or path instead of the default `.env.build`.
+</Tip>
+
+<Warning>
+  Ensure that `.env.build` is ignored during commits to avoid accidentally making secrets public.
+</Warning>
+
+### blaxel.toml
+
+Non-secret build variables that can be placed in the `blaxel.toml` file, as in the example below:
+
+```toml blaxel.toml
+type = "agent"
+name = "my-agent"
+
+[build.args]
+MY_BUILD_VAR = "I_AM_NOT_A_SECRET"
+```
+
 ## Reserved variables
 
 The following variables are reserved by Blaxel:

--- a/deployment-reference.mdx
+++ b/deployment-reference.mdx
@@ -33,6 +33,11 @@ The format of Blaxel's configuration file is described below.
 # defaults to true
 # slim = true
 
+# build-time variables (optional)
+# should be used for non-secret values only
+# [build.args]
+# MY_BUILD_VAR = "my-value"
+
 # entrypoint configuration (optional)
 # [entrypoint]
 # entrypoint command for production environment


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a "Build variables" section to the Variables and Secrets docs for Agents, Functions, and Jobs, plus updates the deployment reference. Documents two mechanisms: `.env.build` for build-time secrets and `blaxel.toml` `[build.args]` for non-secret build variables.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8b7f6136cd40eb5719a8f9f6aad3185a4b327d05.</sup>
<!-- /MENDRAL_SUMMARY -->