### PR TITLE
chore: auto-update cli docs from upstream

### DIFF
--- a/cli-reference/commands/bl_deploy.md
+++ b/cli-reference/commands/bl_deploy.md
@@ -66,6 +66,9 @@ bl deploy [flags]
   # Deploy specifying a resource type
   bl deploy --type sandbox
 
+  # Deploy with Docker build args from a .env.build file
+  bl deploy --build-env-file .env.build.production
+
   # Recursively deploy all projects in monorepo
   bl deploy -R
 ```
@@ -73,6 +76,7 @@ bl deploy [flags]
 ### Options
 
 ```
+      --build-env-file string       Path to a build env file with Docker build args (default: auto-detect .env.build)
   -d, --directory string            Deployment app path, can be a sub directory
       --docker-config string        Path to a Docker config.json file with registry credentials
       --dryrun                      Dry run the deployment

--- a/cli-reference/commands/bl_push.md
+++ b/cli-reference/commands/bl_push.md
@@ -49,6 +49,7 @@ bl push [flags]
 ### Options
 
 ```
+      --build-env-file string       Path to a build env file with Docker build args (default: auto-detect .env.build)
   -d, --directory string            Source directory path
       --docker-config string        Path to a Docker config.json file with registry credentials
   -h, --help                        help for push

--- a/cli-reference/commands/bl_run.md
+++ b/cli-reference/commands/bl_run.md
@@ -102,6 +102,9 @@ bl run resource-type resource-name [flags]
   # Execute a command with a working directory and a process name
   bl run sandbox my-sandbox --path /process --data '{"command": "npm install", "name": "install-deps", "workingDir": "/app"}'
 
+  # For complex commands (nested quotes, backslashes, multiline), save the JSON in a file with your editor then pass it via --file (no shell-escaping)
+  bl run sandbox my-sandbox --path /process --file ./process-payload.json
+
   # Execute a long-running command with keep-alive (prevents sandbox auto-standby)
   bl run sandbox my-sandbox --path /process --data '{"command": "npm run dev -- --port 3000", "name": "dev-server", "keepAlive": true}'
 


### PR DESCRIPTION
Automated update of CLI docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Automated CLI docs update adding `--build-env-file` flag documentation to `bl deploy` and `bl push`, and a `--file` flag usage example to `bl run`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9ae53aa4b7e06967657e3e87d5a426065b54bf1e.</sup>
<!-- /MENDRAL_SUMMARY -->