### PR TITLE
docs: update changelog

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,22 @@ description: 'Chronological list of all platform updates, new features, deprecat
   [Subscribe to this changelog's RSS feed](https://docs.blaxel.ai/changelog/rss.xml) for automated notifications of platform changes and new features.
 </Tip>
 
+<Update label="2026-05-01">
+
+### Support for build variables
+
+Pass build secrets and configuration values into the Docker build phase without exposing them at runtime. Available for agent, job and MCP server builds.
+
+</Update>
+
+<Update label="2026-04-26">
+
+### Further rollout of proxy and egress gateway
+
+[Proxy routing](/Sandboxes/Proxy#proxy-routing), [domain filtering](/Sandboxes/Proxy#domain-filtering-firewall) and [egress gateway](/Infrastructure/Dedicated-egress-gateways) features now available in all regions.
+
+</Update>
+
 <Update label="2026-04-24">
 
 ### New Billing Explorer API

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -17,9 +17,9 @@ Pass build secrets and configuration values into the Docker build phase without 
 
 <Update label="2026-04-26">
 
-### Further rollout of proxy and egress gateway
+### Further rollout of proxy and egress gateway features
 
-[Proxy routing](/Sandboxes/Proxy#proxy-routing), [domain filtering](/Sandboxes/Proxy#domain-filtering-firewall) and [egress gateway](/Infrastructure/Dedicated-egress-gateways) features now available in all regions.
+[Proxy](/Sandboxes/Proxy) and [egress gateway](/Infrastructure/Dedicated-egress-gateways) now available in all regions.
 
 </Update>
 


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds two new changelog entries for "Support for build variables" (2026-05-01) and "Further rollout of proxy and egress gateway" (2026-04-26), inserted in chronological order above the existing 2026-04-24 entry. The follow-up commit (e4cb0e9) updates copy in the new entries.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e4cb0e94893e94e81d1f868eb47b604b462651bc.</sup>
<!-- /MENDRAL_SUMMARY -->