### PR TITLE
docs: add shared job image page

### DIFF
--- a/Jobs/Deploy-a-job.mdx
+++ b/Jobs/Deploy-a-job.mdx
@@ -254,6 +254,10 @@ Using a custom Dockerfile allows for [deploying multiple jobs from the same repo
   Deploy multiple jobs with shared context from a single repository.
 </Card>
 
+<Card title="Deploy multiple jobs from a single image" icon="image" href="/Jobs/Deploy-shared-image">
+  Reuse a job image across multiple job definitions.
+</Card>
+
 ## Template directory reference
 
 ### Overview

--- a/Jobs/Deploy-multiple-jobs.mdx
+++ b/Jobs/Deploy-multiple-jobs.mdx
@@ -10,7 +10,7 @@ You can use a **shared context from a same single repository** to deploy multipl
 
 ## Deploying multiple resources
 
-With the `--directory` (`-d`) parameter in `bl deploy`, you can specify a subfolder containing your `blaxel.toml` and `Dockerfile`. 
+With the `--directory` (`-d`) parameter in `bl deploy`, you can specify a subfolder containing your `blaxel.toml` and `Dockerfile`.
 
 The `Dockerfile` defines how your deployment context is built and as such is required if you want to ensure proper mounting of shared dependencies between your different services.
 

--- a/Jobs/Deploy-shared-image.mdx
+++ b/Jobs/Deploy-shared-image.mdx
@@ -61,7 +61,7 @@ spec:
   region: us-was-1
   runtime:
     diskPercent: 50
-    image: job/github-runner-dev:jv7lsvdihfqz
+    image: job/github-runner-dev:<your-image-digest>  # from: bl get job github-runner-dev -o json | jq -r '.[].spec.runtime.image'
     memory: 4096
     timeout: 3600
 ```

--- a/Jobs/Deploy-shared-image.mdx
+++ b/Jobs/Deploy-shared-image.mdx
@@ -1,0 +1,85 @@
+---
+title: "Deploy multiple jobs from a single image"
+description: "Reuse a job image across multiple job definitions."
+---
+
+You can build a job image once and reuse it across multiple job definitions (e.g. different memory / disk / region profiles) without rebuilding.
+
+The workflow is:
+
+1. Build and push the image through a single "dev" job.
+2. Reference the resulting image digest from as many `Job` manifests as you need.
+3. Roll out changes to production runners by re-applying the manifests.
+
+This is particularly useful when images are large: a full rollout across every host can take up to 20 minutes, so sharing one image across many jobs is much cheaper than rebuilding per job.
+
+## 1. Build the image via a dev job
+
+Create a `blaxel.toml` describing the dev job used to build and host the image:
+
+```toml
+type = "job"
+name = "github-runner-dev"
+
+[runtime]
+diskPercent = 50
+memory = 4096
+timeout = 3600
+maxRetries = 0
+```
+
+Deploy it with:
+
+```bash
+bl deploy
+```
+
+Alternatively, use the command below to push the image without deploying it:
+
+```bash
+bl push
+```
+
+Once deployed, obtain the image reference:
+
+```bash
+bl get job github-runner-dev -o json | jq -r '.[].spec.runtime.image'
+# -> job/github-runner-dev:jv7lsvdihfqz
+```
+
+## 2. Create one manifest per runner profile
+
+For every runner variant you need (size, region, timeout, ...), write a small `Job` manifest that points at the image produced above.
+
+```yaml
+# 4grunner.yaml
+apiVersion: blaxel.ai/v1alpha1
+kind: Job
+metadata:
+  name: github-runner-4g
+spec:
+  region: us-was-1
+  runtime:
+    diskPercent: 50
+    image: job/github-runner-dev:jv7lsvdihfqz
+    memory: 4096
+    timeout: 3600
+```
+
+Apply it:
+
+```bash
+bl apply -f 4grunner.yaml
+```
+
+You can bootstrap a new manifest from the dev job's current spec:
+
+```bash
+bl get job github-runner-dev -o yaml
+```
+
+## 3. Create additional jobs from the shared image
+
+You can now use the same image to deploy jobs with different manifests/runner profiles, depending on your requirements. Because the image is shared, hosts only pull it once instead of once per job.
+
+To update the image, you can build a new image on `github-runner-dev`, validate it there, then promote it to production by bumping the `image:` field in each manifest and re-applying.

--- a/docs.json
+++ b/docs.json
@@ -91,7 +91,8 @@
                 "pages": [
                   "Jobs/Deploy-a-job",
                   "Jobs/Deploy-dockerfile-jobs",
-                  "Jobs/Deploy-multiple-jobs"
+                  "Jobs/Deploy-multiple-jobs",
+                  "Jobs/Deploy-shared-image"
                 ]
               },
               {


### PR DESCRIPTION
Based on content provided by @drappier-charles 

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new `Deploy-shared-image.mdx` page explaining how to build a job image once and reuse it across multiple job definitions with different runtime profiles. Registers the page in `docs.json` and adds a cross-link card from the existing deploy page.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e455d7e5a0bae27dd9c1912180242b147cca73be.</sup>
<!-- /MENDRAL_SUMMARY -->