### PR TITLE
docs: add tailscale in sandbox tutorial

### DIFF
--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -306,6 +306,38 @@ You can use these labels for filtering sandboxes in the Blaxel CLI or Blaxel Con
 bl get sandboxes -o json | jq -r '.[] | select(.metadata.labels.env == "dev") | .metadata.name'
 ```
 
+### Kernel networking
+
+By default, sandboxes run on a minimal kernel without iptables support. You can enable iptables by passing `extraArgs` at creation time.
+
+<Note>
+   `extraArgs` can only be set when creating a sandbox. It cannot be changed after creation.
+</Note>
+
+<CodeGroup>
+
+```typescript TypeScript
+import { SandboxInstance } from "@blaxel/core";
+
+const sandbox = await SandboxInstance.create({
+  name: "my-sandbox",
+  extraArgs: { iptables: "enabled" },
+});
+```
+
+```python Python
+from blaxel.core import SandboxInstance
+
+sandbox = await SandboxInstance.create({
+    "name": "my-sandbox",
+    "extra_args": {"iptables": "enabled"},
+})
+```
+
+</CodeGroup>
+
+For a complete example of using iptables to run Tailscale inside a sandbox, see the [Tailscale tutorial](/Tutorials/Tailscale).
+
 ### Expiration
 
 Blaxel supports [automatic sandbox deletion](./Expiration) based on specific conditions.

--- a/Tutorials/Sandboxes-Overview.mdx
+++ b/Tutorials/Sandboxes-Overview.mdx
@@ -15,4 +15,7 @@ Blaxel lets you run Web applications inside a Blaxel sandbox and preview the con
   <Card title="Next.js" href="/Tutorials/Nextjs">
     Run Next.js in a sandbox.
   </Card>
+  <Card title="Tailscale" href="/Tutorials/Tailscale">
+    Run Tailscale in a sandbox.
+  </Card>
 </CardGroup>

--- a/Tutorials/Tailscale.mdx
+++ b/Tutorials/Tailscale.mdx
@@ -193,7 +193,8 @@ async def setup_tailscale():
     # 4. Authenticate and bring up the interface
     up = await sandbox.process.exec({
         "name": "tailscale-up",
-        "command": f"tailscale up --authkey={TS_AUTHKEY} --hostname={SANDBOX_NAME} --ssh",
+        "command": f"tailscale up --authkey=$TS_AUTHKEY --hostname={SANDBOX_NAME} --ssh",
+        "env": {"TS_AUTHKEY": TS_AUTHKEY},
         "wait_for_completion": True,
         "timeout": 30000,
     })

--- a/Tutorials/Tailscale.mdx
+++ b/Tutorials/Tailscale.mdx
@@ -1,0 +1,181 @@
+---
+title: 'Run Tailscale in a sandbox'
+description: 'Connect a Blaxel sandbox to your Tailscale network and access it via SSH from any device.'
+---
+
+This tutorial shows how to run [Tailscale](https://tailscale.com/) inside a Blaxel sandbox. Once set up, your sandbox is reachable via SSH from any device on your Tailscale network.
+
+## Prerequisites
+
+- A [Tailscale](https://tailscale.com/) account
+- A Tailscale authentication key (see below)
+- Blaxel SDK installed in your project
+
+## Generate a Tailscale authentication key
+
+1. Go to [https://login.tailscale.com/admin/settings/keys](https://login.tailscale.com/admin/settings/keys)
+2. Click **Generate auth key**
+3. Configure the key:
+   - **Reusable** — enable if you want to use the same key across multiple sandboxes
+   - **Ephemeral** — recommended for sandboxes: the node is automatically removed from your Tailscale network when it disconnects
+   - **Expiry** — set an appropriate duration (e.g. 90 days)
+4. Click **Generate key** and copy the value, typically starting with `tskey-auth-...`
+
+Then set it as an environment variable:
+
+```sh
+export TS_AUTHKEY=tskey-auth-...
+```
+
+## Create a sandbox with `iptables` enabled
+
+Tailscale requires iptables, which is not enabled in sandboxes by default. You enable it by passing [`extraArgs` at creation time](/Sandboxes/Overview#kernel-networking).
+
+## Install and configure Tailscale in the sandbox
+
+Next, install the `tailscale` and `iptables` packages and start the `tailscaled` daemon as a background process.
+
+```sh
+# Install dependencies
+apk add tailscale iptables
+
+# Start the daemon
+tailscaled &
+```
+
+You can then run `tailscale up --ssh` to authenticate and enable Tailscale SSH.
+
+```sh
+# Authenticate and enable Tailscale SSH
+# Prints an auth URL if no key is provided, or authenticates silently with a key
+tailscale up --hostname=my-sandbox --ssh
+# or: tailscale up --authkey=$TS_AUTHKEY --hostname=my-sandbox --ssh
+```
+
+Retrieve the Tailscale IP.
+
+```sh
+# Get your Tailscale IP
+tailscale ip
+```
+
+Once authenticated, the sandbox is reachable via SSH from any device on your Tailscale network:
+
+```sh
+ssh root@<tailscale-ip>
+# or using the hostname directly:
+ssh root@my-sandbox
+```
+
+## Appendix: Using the SDK
+
+It's also possible to create a sandbox and configure Tailscale using the Blaxel SDKs:
+
+<CodeGroup>
+
+```typescript TypeScript
+import { SandboxInstance } from "@blaxel/core";
+
+const TS_AUTHKEY = process.env.TS_AUTHKEY!;
+const SANDBOX_NAME = "tailscale-sandbox";
+
+// 1. Create sandbox with iptables enabled
+const sandbox = await SandboxInstance.create({
+  name: SANDBOX_NAME,
+  extraArgs: { iptables: "enabled" },
+});
+
+// 2. Install dependencies
+await sandbox.process.exec({
+  name: "install-deps",
+  command: "apk add --no-cache tailscale iptables",
+  waitForCompletion: true,
+  timeout: 60000,
+});
+
+// 3. Start the tailscaled daemon in the background
+await sandbox.process.exec({
+  name: "tailscaled",
+  command: "tailscaled",
+  keepAlive: true,
+  timeout: 0, // run indefinitely
+});
+
+// Give the daemon a moment to initialize
+await new Promise((r) => setTimeout(r, 2000));
+
+// 4. Authenticate and bring up the interface
+const up = await sandbox.process.exec({
+  name: "tailscale-up",
+  command: `tailscale up --authkey=${TS_AUTHKEY} --hostname=${SANDBOX_NAME} --ssh`,
+  waitForCompletion: true,
+  timeout: 30000,
+});
+console.log("tailscale up:", up.logs);
+
+// 5. Get the Tailscale IP
+const ip = await sandbox.process.exec({
+  name: "tailscale-ip",
+  command: "tailscale ip",
+  waitForCompletion: true,
+  timeout: 10000,
+});
+console.log("Tailscale IP:", ip.logs?.trim());
+```
+
+```python Python
+import asyncio
+import os
+from blaxel.core import SandboxInstance
+
+TS_AUTHKEY = os.environ["TS_AUTHKEY"]
+SANDBOX_NAME = "tailscale-sandbox"
+
+async def setup_tailscale():
+    # 1. Create sandbox with iptables enabled
+    sandbox = await SandboxInstance.create({
+        "name": SANDBOX_NAME,
+        "extra_args": {"iptables": "enabled"},
+    })
+
+    # 2. Install dependencies
+    await sandbox.process.exec({
+        "name": "install-deps",
+        "command": "apk add --no-cache tailscale iptables",
+        "wait_for_completion": True,
+        "timeout": 60000,
+    })
+
+    # 3. Start the tailscaled daemon in the background
+    await sandbox.process.exec({
+        "name": "tailscaled",
+        "command": "tailscaled",
+        "keep_alive": True,
+        "timeout": 0,  # run indefinitely
+    })
+
+    # Give the daemon a moment to initialize
+    await asyncio.sleep(2)
+
+    # 4. Authenticate and bring up the interface
+    up = await sandbox.process.exec({
+        "name": "tailscale-up",
+        "command": f"tailscale up --authkey={TS_AUTHKEY} --hostname={SANDBOX_NAME} --ssh",
+        "wait_for_completion": True,
+        "timeout": 30000,
+    })
+    print("tailscale up:", up.logs)
+
+    # 5. Get the Tailscale IP
+    ip = await sandbox.process.exec({
+        "name": "tailscale-ip",
+        "command": "tailscale ip",
+        "wait_for_completion": True,
+        "timeout": 10000,
+    })
+    print("Tailscale IP:", ip.logs.strip())
+
+asyncio.run(setup_tailscale())
+```
+
+</CodeGroup>

--- a/Tutorials/Tailscale.mdx
+++ b/Tutorials/Tailscale.mdx
@@ -140,7 +140,8 @@ await new Promise((r) => setTimeout(r, 2000));
 // 4. Authenticate and bring up the interface
 const up = await sandbox.process.exec({
   name: "tailscale-up",
-  command: `tailscale up --authkey=${TS_AUTHKEY} --hostname=${SANDBOX_NAME} --ssh`,
+  command: `tailscale up --authkey=$TS_AUTHKEY --hostname=${SANDBOX_NAME} --ssh`,
+  env: { TS_AUTHKEY },
   waitForCompletion: true,
   timeout: 30000,
 });

--- a/Tutorials/Tailscale.mdx
+++ b/Tutorials/Tailscale.mdx
@@ -7,13 +7,16 @@ This tutorial shows how to run [Tailscale](https://tailscale.com/) inside a Blax
 
 ## Prerequisites
 
-- A [Tailscale](https://tailscale.com/) account
-- A Tailscale authentication key (see below)
-- Blaxel SDK installed in your project
+Before starting, ensure you have:
 
-## Generate a Tailscale authentication key
+- a [Blaxel account](https://blaxel.ai)
+- a [Tailscale account](https://tailscale.com/)
+- a Tailscale authentication key
+- the Blaxel TypeScript or Python SDK installed in your project
 
-1. Go to [https://login.tailscale.com/admin/settings/keys](https://login.tailscale.com/admin/settings/keys)
+To generate a a Tailscale authentication key:
+
+1. Log in to your Tailscale account and navigate to the administration section.
 2. Click **Generate auth key**
 3. Configure the key:
    - **Reusable** — enable if you want to use the same key across multiple sandboxes
@@ -27,11 +30,39 @@ Then set it as an environment variable:
 export TS_AUTHKEY=tskey-auth-...
 ```
 
-## Create a sandbox with `iptables` enabled
+## Create a sandbox
 
 Tailscale requires iptables, which is not enabled in sandboxes by default. You enable it by passing [`extraArgs` at creation time](/Sandboxes/Overview#kernel-networking).
 
+<CodeGroup>
+
+```typescript TypeScript
+import { SandboxInstance } from "@blaxel/core";
+
+const sandbox = await SandboxInstance.create({
+  name: "tailscale-sandbox",
+  extraArgs: { iptables: "enabled" },
+});
+```
+
+```python Python
+from blaxel.core import SandboxInstance
+
+sandbox = await SandboxInstance.create({
+    "name": "tailscale-sandbox",
+    "extra_args": {"iptables": "enabled"},
+})
+```
+
+</CodeGroup>
+
 ## Install and configure Tailscale in the sandbox
+
+Connect to the sandbox terminal:
+
+```sh
+bl connect tailscale-sandbox
+```
 
 Next, install the `tailscale` and `iptables` packages and start the `tailscaled` daemon as a background process.
 
@@ -59,6 +90,8 @@ Retrieve the Tailscale IP.
 tailscale ip
 ```
 
+## Connect to the sandbox using Tailscale
+
 Once authenticated, the sandbox is reachable via SSH from any device on your Tailscale network:
 
 ```sh
@@ -69,7 +102,7 @@ ssh root@my-sandbox
 
 ## Appendix: Using the SDK
 
-It's also possible to create a sandbox and configure Tailscale using the Blaxel SDKs:
+It's also possible to create a sandbox and configure Tailscale using the Blaxel SDKs instead of the sandbox terminal:
 
 <CodeGroup>
 

--- a/docs.json
+++ b/docs.json
@@ -275,7 +275,8 @@
               "Tutorials/Astro",
               "Tutorials/Expo",
               "Tutorials/Nextjs",
-              "Tutorials/Code-server"
+              "Tutorials/Code-server",
+              "Tutorials/Tailscale"
             ]
           },
           {


### PR DESCRIPTION
Based on content provided by @drappier-charles

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a Tailscale tutorial showing how to run Tailscale inside a Blaxel sandbox, including a new `Kernel networking` section in the Sandboxes overview documenting the `extraArgs`/`iptables` option, SDK examples for both TypeScript and Python, and nav wiring.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d05a3133f722f816f244712c67ddc852e4f0dcc0.</sup>
<!-- /MENDRAL_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->