### PR TITLE
docs: update OpenAI tutorials

### DIFF
--- a/Tutorials/Claude-Agent-SDK.mdx
+++ b/Tutorials/Claude-Agent-SDK.mdx
@@ -36,22 +36,22 @@ In your project directory, install the [Claude Agent SDK](https://platform.claud
 
 ```shell TypeScript (npm)
 npm init # if new project
-npm install @anthropic-ai/claude-agent-sdk express
+npm install @anthropic-ai/claude-agent-sdk express tsx typescript
 ```
 
 ```shell TypeScript (pnpm)
 pnpm init # if new project
-pnpm install @anthropic-ai/claude-agent-sdk express
+pnpm install @anthropic-ai/claude-agent-sdk express tsx typescript
 ```
 
 ```shell TypeScript (yarn)
 yarn init # if new project
-yarn add @anthropic-ai/claude-agent-sdk express
+yarn add @anthropic-ai/claude-agent-sdk express tsx typescript
 ```
 
 ```shell TypeScript (bun)
 bun init -m --yes # if new project
-bun install @anthropic-ai/claude-agent-sdk express
+bun add @anthropic-ai/claude-agent-sdk express tsx typescript
 ```
 
 ```shell Python (pip)

--- a/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
+++ b/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
@@ -37,16 +37,28 @@ mkdir sandbox-agent && cd sandbox-agent
 
 In your project directory, install the [OpenAI Agents SDK with Blaxel support](https://developers.openai.com/api/docs/guides/agents-sdk) for the agent loop:
 
-```shell
+<CodeGroup>
+```shell TypeScript
+npm install @openai/agents @openai/agents-extensions @blaxel/core zod
+```
+
+```shell Python
 python3 -m venv .venv && source .venv/bin/activate # if new project
 pip install openai-agents[blaxel]
 ```
+</CodeGroup>
 
-Agents deployed on Blaxel Agents Hosting must expose an HTTP endpoint for requests. An easy way to do this is with [FastAPI](https://fastapi.tiangolo.com) - install it as below:
+Agents deployed on Blaxel Agents Hosting must expose an HTTP endpoint for requests. An easy way to do this is with [Express](https://expressjs.com) (TypeScript) or [FastAPI](https://fastapi.tiangolo.com) (Python):
 
-```shell
+<CodeGroup>
+```shell TypeScript
+npm install express @types/express
+```
+
+```shell Python
 pip install fastapi uvicorn
 ```
+</CodeGroup>
 
 ## 3. Configure the environment
 
@@ -60,14 +72,64 @@ echo "BL_WORKSPACE=your_workspace_name_here" >> .env
 
 ## 4. Build a simple agent
 
-In your project directory, create a file named `main.py` with the following code.
+In your project directory, create a file named `main.py` (Python) or `index.ts` (TypeScript) with the following code:
 
-```python
+<CodeGroup>
+
+```typescript TypeScript
+import { run } from "@openai/agents";
+import { Manifest, SandboxAgent } from "@openai/agents/sandbox";
+import { BlaxelSandboxClient } from "@openai/agents-extensions/sandbox/blaxel";
+import express from "express";
+
+const app = express();
+app.use(express.json());
+
+const host = process.env.HOST ?? "0.0.0.0";
+const port = parseInt(process.env.PORT ?? "8000");
+
+app.post("/query", async (req, res) => {
+  const { task } = req.body;
+
+  const client = new BlaxelSandboxClient();
+
+  const agent = new SandboxAgent({
+    name: "Sandbox agent",
+    model: "gpt-5.4",
+    instructions:
+      "You have access to a minimal sandbox environment. You can execute commands, manage files, and inspect processes inside the sandbox.",
+    modelSettings: { toolChoice: "auto" },
+    defaultManifest: new Manifest({ root: "/blaxel" }),
+  });
+
+  const result = await run(agent, task, {
+    maxTurns: 50,
+    sandbox: {
+      client,
+      manifest: new Manifest({ root: "/blaxel" }),
+      options: {
+        name: "agent-sandbox",
+        image: "blaxel/base-image",
+        region: "us-pdx-1",
+        memory: 4096,
+      },
+    },
+  });
+
+  res.json({ result: result.finalOutput });
+});
+
+app.listen(port, host, () => {
+  console.log(`Server listening on ${host}:${port}`);
+});
+```
+
+```python Python
 import os
 import uvicorn
 from fastapi import FastAPI, Request
 
-from agents import ModelSettings, Runner, set_tracing_disabled
+from agents import ModelSettings, Runner
 from agents.run import RunConfig
 from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig
 from agents.extensions.sandbox import BlaxelSandboxClient, BlaxelSandboxClientOptions
@@ -109,10 +171,10 @@ async def query(request: Request):
 
 
 if __name__ == "__main__":
-    set_tracing_disabled(True)
     print(f"Server listening on {host}:{port}")
     uvicorn.run(app, host=host, port=port)
 ```
+</CodeGroup>
 
 This creates a simple sandbox-backed agent with the OpenAI Agents SDK. Queries that you send the agent will be executed in a sandbox named `agent-sandbox` that is dynamically created and managed in your workspace on Blaxel's infrastructure.
 
@@ -125,13 +187,27 @@ This creates a simple sandbox-backed agent with the OpenAI Agents SDK. Queries t
 Instrumentation happens automatically when workloads run on Blaxel. To enable telemetry:
 
 - Add the required package to your project:
-  ```shell
+
+  <CodeGroup>
+  ```shell TypeScript
+  npm install @blaxel/telemetry
+  ```
+
+  ```shell Python
   pip install "blaxel[telemetry]"
   ```
+  </CodeGroup>
+
 - Import the package in your code:
-  ```python
+  <CodeGroup>
+  ```typescript TypeScript
+  import "@blaxel/telemetry";
+  ```
+
+  ```python Python
   import blaxel.telemetry
   ```
+  </CodeGroup>
 
 ## 6. Test the agent locally
 
@@ -159,13 +235,15 @@ The agent will create and deploy a Blaxel sandbox using the `blaxel/base-image` 
 
 You're now ready to deploy the agent on Blaxel. When deploying to Blaxel, your workloads are served optimally to dramatically accelerate cold-start and latency while enforcing your deployment policies.
 
-First, create a `requirements.txt` file in the project directory with the following dependencies:
+For Python, create a `requirements.txt` file in the project directory with the following dependencies:
 
-```shell
+```shell Python
 fastapi>=0.135.3
 uvicorn>=0.35.0
 openai-agents[blaxel]
 ```
+
+For TypeScript, your `package.json` already contains all required dependencies from the `npm install` commands run earlier. No additional file is needed.
 
 Then, deploy the agent by running the following command:
 

--- a/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
+++ b/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
@@ -42,22 +42,22 @@ In your project directory, install the [OpenAI Agents SDK with Blaxel support](h
 <CodeGroup>
 ```shell TypeScript (npm)
 npm init # if new project
-npm install @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express
+npm install @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express tsx typescript
 ```
 
 ```shell TypeScript (pnpm)
 pnpm init # if new project
-pnpm install @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express
+pnpm install @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express tsx typescript
 ```
 
 ```shell TypeScript (yarn)
 yarn init # if new project
-yarn add @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express
+yarn add @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express tsx typescript
 ```
 
 ```shell TypeScript (bun)
 bun init -m --yes # if new project
-bun install @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express
+bun add @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express
 ```
 
 ```shell Python (pip)

--- a/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
+++ b/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
@@ -35,28 +35,34 @@ Create a directory for the project:
 mkdir sandbox-agent && cd sandbox-agent
 ```
 
-In your project directory, install the [OpenAI Agents SDK with Blaxel support](https://developers.openai.com/api/docs/guides/agents-sdk) for the agent loop:
+Agents deployed on Blaxel Agents Hosting must expose an HTTP endpoint for requests.
+
+In your project directory, install the [OpenAI Agents SDK with Blaxel support](https://developers.openai.com/api/docs/guides/agents-sdk) for the agent loop and [Express](https://expressjs.com/) (TypeScript) / [FastAPI](https://fastapi.tiangolo.com/) (Python) to handle HTTP requests and responses:
 
 <CodeGroup>
-```shell TypeScript
-npm install @openai/agents @openai/agents-extensions @blaxel/core zod
+```shell TypeScript (npm)
+npm init # if new project
+npm install @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express
 ```
 
-```shell Python
+```shell TypeScript (pnpm)
+pnpm init # if new project
+pnpm install @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express
+```
+
+```shell TypeScript (yarn)
+yarn init # if new project
+yarn add @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express
+```
+
+```shell TypeScript (bun)
+bun init -m --yes # if new project
+bun install @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express
+```
+
+```shell Python (pip)
 python3 -m venv .venv && source .venv/bin/activate # if new project
-pip install openai-agents[blaxel]
-```
-</CodeGroup>
-
-Agents deployed on Blaxel Agents Hosting must expose an HTTP endpoint for requests. An easy way to do this is with [Express](https://expressjs.com) (TypeScript) or [FastAPI](https://fastapi.tiangolo.com) (Python):
-
-<CodeGroup>
-```shell TypeScript
-npm install express @types/express
-```
-
-```shell Python
-pip install fastapi uvicorn
+pip install openai-agents[blaxel] fastapi uvicorn
 ```
 </CodeGroup>
 
@@ -106,7 +112,6 @@ app.post("/query", async (req, res) => {
     maxTurns: 50,
     sandbox: {
       client,
-      manifest: new Manifest({ root: "/blaxel" }),
       options: {
         name: "agent-sandbox",
         image: "blaxel/base-image",
@@ -182,18 +187,52 @@ This creates a simple sandbox-backed agent with the OpenAI Agents SDK. Queries t
   The agent's HTTP service must be bound to the host and port provided by Blaxel. Blaxel automatically injects these values as `HOST` and `PORT` variables into the runtime environment. It is important to read these variables in your code and ensure that the agent's HTTP service binds to the correct host and port.
 </Note>
 
+In TypeScript, entrypoints are managed in the `scripts` section of the `package.json` file. Update your `package.json` to ensure that `start` and `dev` scripts are defined in the `scripts` section (TypeScript only).
+
+<CodeGroup>
+
+```json TypeScript (npm/pnpm/yarn)
+{
+  "scripts": {
+    "start": "tsx index.ts",
+    "dev": "tsx --watch index.ts",
+    "build": "tsc"
+  },
+  // ...
+}
+```
+
+```json TypeScript (bun)
+{
+  "scripts": {
+    "start": "bun run index.ts",
+    "dev": "bun --watch index.ts"
+  },
+  // ...
+}
+```
+
+</CodeGroup>
+
 ## 5. Enable telemetry (optional)
 
 Instrumentation happens automatically when workloads run on Blaxel. To enable telemetry:
 
 - Add the required package to your project:
-
   <CodeGroup>
-  ```shell TypeScript
+  ```shell TypeScript (npm)
   npm install @blaxel/telemetry
   ```
-
-  ```shell Python
+  ```shell TypeScript (pnpm)
+  pnpm install @blaxel/telemetry
+  ```
+  ```shell TypeScript (yarn)
+  yarn add @blaxel/telemetry
+  ```
+  ```shell TypeScript (bun)
+  bun install @blaxel/telemetry
+  ```
+  ```shell Python (pip)
   pip install "blaxel[telemetry]"
   ```
   </CodeGroup>

--- a/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
+++ b/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
@@ -230,7 +230,7 @@ Instrumentation happens automatically when workloads run on Blaxel. To enable te
   yarn add @blaxel/telemetry
   ```
   ```shell TypeScript (bun)
-  bun install @blaxel/telemetry
+  bun add @blaxel/telemetry
   ```
   ```shell Python (pip)
   pip install "blaxel[telemetry]"
@@ -277,8 +277,8 @@ You're now ready to deploy the agent on Blaxel. When deploying to Blaxel, your w
 For Python, create a `requirements.txt` file in the project directory with the following dependencies:
 
 ```shell Python
-fastapi>=0.135.3
-uvicorn>=0.35.0
+fastapi
+uvicorn
 openai-agents[blaxel]
 ```
 
@@ -305,7 +305,7 @@ curl -X POST https://run.blaxel.ai/$(bl workspace --current)/agents/sandbox-agen
   -H "X-Blaxel-Workspace: $(bl workspace --current)" \
   -H "X-Blaxel-Authorization: Bearer $(bl token)" \
   -H "Content-Type: application/json" \
-  -d '{"task": "Write a Python program to reverse words in a string. Test it. Return the test results and the final working code."}'
+  -d '{"task": "Write a Python program to count how many times each word appears in a sentence. Test it. Return the test results and the final working code."}'
 ```
 
 As before, the agent will create a sandbox, generate the code and provide the result.
@@ -313,7 +313,7 @@ As before, the agent will create a sandbox, generate the code and provide the re
 You can also send a request through the Blaxel CLI:
 
 ```shell
-bl run agent sandbox-agent/query --data '{"task": "Write a Python program to reverse words in a string. Test it. Return the test results and the final working code."}'
+bl run agent sandbox-agent/query --data '{"task": "Write a Python program to count how many times each word appears in a sentence. Test it. Return the test results and the final working code."}'
 ```
 
 <Tip>

--- a/Tutorials/OpenAI-Agents-SDK.mdx
+++ b/Tutorials/OpenAI-Agents-SDK.mdx
@@ -15,7 +15,7 @@ This tutorial explores how you can use the OpenAI Agents SDK with Blaxel to crea
 - A Blaxel workspace and API key. Learn about [Blaxel workspaces](/Security/Workspace-access-control) and how to [obtain a Blaxel API key](/Security/Access-tokens#api-keys).
 
 <Note>
-  The OpenAI Agents SDK is provider-agnostic and can be used with both OpenAI and non-OpenAI models. This tutorial uses OpenAI models, but you can also read about [integrating other models](https://openai.github.io/openai-agents-python/models/#non-openai-models).
+  The OpenAI Agents SDK is provider-agnostic and can be used with both OpenAI and non-OpenAI models. This tutorial uses OpenAI models, but you can also read about [integrating other models with the Python SDK](https://openai.github.io/openai-agents-python/models/#non-openai-models).
 </Note>
 
 ## 1. Install the Blaxel CLI and log in to Blaxel
@@ -36,10 +36,16 @@ mkdir sandbox-agent && cd sandbox-agent
 
 In your project directory, install the [OpenAI Agent SDK with Blaxel support](https://developers.openai.com/api/docs/guides/agents-sdk) for the agent loop:
 
-```shell
+<CodeGroup>
+```shell TypeScript
+npm install @openai/agents @openai/agents-extensions @blaxel/core zod
+```
+
+```shell Python
 python3 -m venv .venv && source .venv/bin/activate # if new project
 pip install openai-agents[blaxel]
 ```
+</CodeGroup>
 
 ## 3. Configure the environment
 
@@ -55,9 +61,50 @@ export BL_WORKSPACE=your_workspace_name_here
 
 In your project directory, create a file named `main.py` with the following code.
 
-```python
+<CodeGroup>
+```typescript TypeScript
+import { run } from "@openai/agents";
+import { Manifest, SandboxAgent } from "@openai/agents/sandbox";
+import { BlaxelSandboxClient } from "@openai/agents-extensions/sandbox/blaxel";
+
+async function main() {
+  const agent = new SandboxAgent({
+    name: "Sandboxed agent",
+    model: "gpt-5.4",
+    instructions:
+      "You have access to a sandbox environment. You can execute commands, manage files, and inspect processes inside the sandbox.",
+    modelSettings: { toolChoice: "auto" },
+    defaultManifest: new Manifest({ root: "/blaxel" }),
+  });
+
+  const client = new BlaxelSandboxClient();
+
+  const result = await run(
+    agent,
+    "Install a complete Go development environment. Once done, return the installed Go version number and Go environment variables.",
+    {
+      maxTurns: 50,
+      sandbox: {
+        client,
+        options: {
+          name: "agent-sandbox-01",
+          image: "blaxel/base-image",
+          region: "us-pdx-1",
+          memory: 4096,
+        },
+      },
+    }
+  );
+
+  console.log(result.finalOutput);
+}
+
+main().catch(console.error);
+```
+
+```python Python
 import asyncio
-from agents import ModelSettings, Runner, set_tracing_disabled
+from agents import ModelSettings, Runner
 from agents.run import RunConfig
 from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig
 from agents.extensions.sandbox import BlaxelSandboxClient, BlaxelSandboxClientOptions
@@ -93,19 +140,13 @@ async def main():
     await client.close()
 
 if __name__ == "__main__":
-    set_tracing_disabled(True)
     asyncio.run(main())
 ```
+</CodeGroup>
 
 This creates a simple sandbox-backed agent with the OpenAI Agents SDK. Instructions that you send the agent will be executed in a sandbox named `agent-sandbox-01` that is dynamically created and managed in your workspace on Blaxel's infrastructure.
 
-Run the agent:
-
-```shell
-python main.py
-```
-
-The agent will create and deploy a Blaxel sandbox using the `blaxel/base-image` image, then investigate the sandbox and install all the tools required for Go development. Once done, it will return a report of its work and automatically delete the sandbox. Here's a partial example of the output:
+Run the agent. It will create and deploy a Blaxel sandbox using the `blaxel/base-image` image, then investigate the sandbox and install all the tools required for Go development. Once done, it will return a report of its work and automatically delete the sandbox. Here's a partial example of the output:
 
 ```shell
 Go is installed and ready.
@@ -130,12 +171,66 @@ In addition to running commands, agents can also create, delete and manage files
 
 To see this in action, update the simple agent from the previous example to perform data processing and analysis in a sandbox:
 
-```python
+<CodeGroup>
+
+```typescript TypeScript
+import { run } from "@openai/agents";
+import { SandboxAgent } from "@openai/agents/sandbox";
+import { BlaxelSandboxClient } from "@openai/agents-extensions/sandbox/blaxel";
+import { writeFileSync } from "fs";
+
+async function main() {
+  const client = new BlaxelSandboxClient();
+  const session = await client.create({
+    options: {
+      name: "agent-sandbox-02",
+      image: "blaxel/py-app",
+      region: "us-pdx-1",
+      memory: 4096,
+    },
+  });
+
+  const agent = new SandboxAgent({
+    name: "Data analyst",
+    model: "gpt-5.4",
+    instructions:
+      "You are a data analyst. You have access to a sandbox environment. You can execute commands, manage files, and inspect processes inside the sandbox.",
+  });
+
+  const stream = await run(
+    agent,
+    "Obtain sample telemetry data using the API https://api.datamock.dev/v1/iot-telemetry?quantity=10&deviceType=wearable_fitness_tracker&exclude=deviceId,ipAddress,macAddress,signalStrength,networkType,location,status,batteryLevel,lastSync,firmwareVersion,alerts." +
+      "Analyze the received data and create a chart showing memory and CPU usage. Save it as /workspace/chart.png. " +
+      "Install any packages you need.",
+    {
+      stream: true,
+      maxTurns: 50,
+      sandbox: { session },
+    }
+  );
+
+  process.stdout.write("assistant> ");
+  stream.toTextStream({ compatibleWithNodeStreams: true }).pipe(process.stdout);
+  await stream.completed;
+  process.stdout.write("\n");
+
+  const chartData = await session.readFile({ path: "/workspace/chart.png" });
+  writeFileSync("chart.png", chartData);
+  console.log("Saved chart to host as chart.png");
+
+  await session.close();
+  await session.shutdown();
+}
+
+main().catch(console.error);
+```
+
+```python Python
 import asyncio
 from pathlib import Path
 
 from openai.types.responses import ResponseTextDeltaEvent
-from agents import Runner, set_tracing_disabled
+from agents import Runner
 from agents.run import RunConfig
 from agents.sandbox import SandboxAgent, SandboxRunConfig
 from agents.extensions.sandbox import BlaxelSandboxClient, BlaxelSandboxClientOptions
@@ -189,21 +284,15 @@ async def main():
 
 
 if __name__ == "__main__":
-    set_tracing_disabled(True)
     asyncio.run(main())
 ```
+</CodeGroup>
 
 In this example, the agent uses Blaxel's `blaxel/py-app` image to create a sandbox containing a complete Python development environment. When the sandbox is created, the SDK automatically also creates a new workspace directory (defaults to `/workspace` but can be configured to point to another location) for the agent to operate in.
 
 The agent then uses sandbox tools to call the remote API, obtains a dataset (mock data), and autonomously installs all the required packages for chart creation. It then prepares and saves a chart of the received data to the workspace at `/workspace/chart.png`. This file is then read from the sandbox session and downloaded to the local host. Once the session is complete, the sandbox is terminated.
 
-Run the agent - once complete, you will have a new `chart.png` file in your project directory containing the generated chart:
-
-```shell
-python main.py
-```
-
-This example also demonstrates the SDK's streaming capabilities - you will see a stream of the agent's reasoning as it works.
+Run the agent - once complete, you will have a new `chart.png` file in your project directory containing the generated chart. This example also demonstrates the SDK's streaming capabilities - you will see a stream of the agent's reasoning as it works.
 
 ## 6. Build a coding agent
 
@@ -211,12 +300,73 @@ One of the most popular uses for agents is to generate code. Sandboxes provide i
 
 To see this in practice, update the agent code in `main.py` as below:
 
-```python
+<CodeGroup>
+
+```typescript TypeScript
+import { run } from "@openai/agents";
+import { Manifest, SandboxAgent } from "@openai/agents/sandbox";
+import { urlForExposedPort } from "@openai/agents-core/sandbox";
+import { BlaxelSandboxClient } from "@openai/agents-extensions/sandbox/blaxel";
+
+async function main() {
+  const task = process.argv.slice(2).join(" ").trim();
+  if (!task) {
+    console.log("Usage: bun index.ts <task>");
+    process.exit(1);
+  }
+
+  const client = new BlaxelSandboxClient();
+  const session = await client.create({
+    manifest: new Manifest({ root: "/blaxel" }),
+    options: {
+      name: "agent-sandbox-03",
+      image: "blaxel/nextjs:latest",
+      region: "us-pdx-1",
+      memory: 4096,
+      exposedPortPublic: true,
+      pauseOnExit: true,
+      ttl: "30m",
+    },
+  });
+
+  const agent = new SandboxAgent({
+    name: "Next.js code generation agent",
+    model: "gpt-5.4",
+    instructions:
+      "You are a Next.js expert with shell access to a sandbox. You can execute commands, manage files, and start servers. The sandbox includes a skeleton Next.js app in /blaxel.",
+    modelSettings: { toolChoice: "auto" },
+  });
+
+  try {
+    const stream = await run(agent, task, {
+      stream: true,
+      maxTurns: 50,
+      sandbox: { session },
+    });
+
+    process.stdout.write("assistant> ");
+    stream.toTextStream({ compatibleWithNodeStreams: true }).pipe(process.stdout);
+    await stream.completed;
+    process.stdout.write("\n");
+
+    const endpoint = await session.resolveExposedPort(3000);
+    const previewUrl = urlForExposedPort(endpoint, "http");
+    console.log(`Preview URL: ${previewUrl}`);
+  } finally {
+    await session.close();
+    await session.shutdown();
+  }
+}
+
+main().catch(console.error);
+```
+
+```python Python
 import asyncio
 import sys
 
 from openai.types.responses import ResponseTextDeltaEvent
-from agents import ModelSettings, Runner, set_tracing_disabled
+from agents import ModelSettings, Runner
 from agents.run import RunConfig
 from agents.sandbox import Manifest, SandboxAgent, SandboxRunConfig
 from agents.extensions.sandbox import BlaxelSandboxClient, BlaxelSandboxClientOptions
@@ -277,9 +427,10 @@ async def main():
 
 
 if __name__ == "__main__":
-    set_tracing_disabled(True)
     asyncio.run(main())
 ```
+
+</CodeGroup>
 
 This creates a Next.js coding agent that accepts requests from the command-line. The coding agent's sandbox is generated from Blaxel's `blaxel/nextjs` image, which contains a complete Next.js development environment and a Next.js skeleton application. Notice the `ttl` parameter, which sets an [expiration policy](/Sandboxes/Expiration) to automatically delete the sandbox after 30 minutes.
 
@@ -287,9 +438,16 @@ In addition, the `exposed_port_public` parameter and the `resolve_exposed_port()
 
 Test the agent:
 
-```shell
+<CodeGroup>
+
+```shell TypeScript
+node main.ts "My cat Kitty does amazing things. Create a website about her."
+```
+
+```shell Python
 python main.py "My cat Kitty does amazing things. Create a website about her."
 ```
+</CodeGroup>
 
 The agent will start working on the task in a sandbox, streaming its responses as it works. Once it is complete, you should see a preview URL similar to the following:
 

--- a/Tutorials/OpenAI-Agents-SDK.mdx
+++ b/Tutorials/OpenAI-Agents-SDK.mdx
@@ -59,7 +59,7 @@ export BL_WORKSPACE=your_workspace_name_here
 
 ## 4. Build a simple agent
 
-In your project directory, create a file named `main.py` with the following code.
+In your project directory, create a file named `index.ts` (TypeScript) or `main.py` (Python) with the following code.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -298,7 +298,7 @@ Run the agent - once complete, you will have a new `chart.png` file in your proj
 
 One of the most popular uses for agents is to generate code. Sandboxes provide isolated execution environments, allowing agents to securely run generated code with no risk of escaping. Blaxel sandboxes offer a unique advantage here: human operators can preview agent-generated applications in real-time via direct preview URLs for each running sandbox.
 
-To see this in practice, update the agent code in `main.py` as below:
+To see this in practice, update the agent code in `index.ts` / `main.py` as below:
 
 <CodeGroup>
 
@@ -311,7 +311,7 @@ import { BlaxelSandboxClient } from "@openai/agents-extensions/sandbox/blaxel";
 async function main() {
   const task = process.argv.slice(2).join(" ").trim();
   if (!task) {
-    console.log("Usage: bun index.ts <task>");
+    console.log("Usage: node index.ts <task>");
     process.exit(1);
   }
 
@@ -441,7 +441,7 @@ Test the agent:
 <CodeGroup>
 
 ```shell TypeScript
-node main.ts "My cat Kitty does amazing things. Create a website about her."
+node index.ts "My cat Kitty does amazing things. Create a website about her."
 ```
 
 ```shell Python

--- a/Tutorials/OpenAI-Agents-SDK.mdx
+++ b/Tutorials/OpenAI-Agents-SDK.mdx
@@ -37,8 +37,24 @@ mkdir sandbox-agent && cd sandbox-agent
 In your project directory, install the [OpenAI Agent SDK with Blaxel support](https://developers.openai.com/api/docs/guides/agents-sdk) for the agent loop:
 
 <CodeGroup>
-```shell TypeScript
+```shell TypeScript (npm)
+npm init # if new project
 npm install @openai/agents @openai/agents-extensions @blaxel/core zod
+```
+
+```shell TypeScript (pnpm)
+pnpm init # if new project
+pnpm install @openai/agents @openai/agents-extensions @blaxel/core zod
+```
+
+```shell TypeScript (yarn)
+yarn init # if new project
+yarn add @openai/agents @openai/agents-extensions @blaxel/core zod
+```
+
+```shell TypeScript (bun)
+bun init -m --yes # if new project
+bun add @openai/agents @openai/agents-extensions @blaxel/core zod
 ```
 
 ```shell Python
@@ -99,7 +115,7 @@ async function main() {
   console.log(result.finalOutput);
 }
 
-main().catch(console.error);
+await main().catch(console.error);
 ```
 
 ```python Python
@@ -222,7 +238,7 @@ async function main() {
   await session.shutdown();
 }
 
-main().catch(console.error);
+await main().catch(console.error);
 ```
 
 ```python Python
@@ -358,7 +374,7 @@ async function main() {
   }
 }
 
-main().catch(console.error);
+await main().catch(console.error);
 ```
 
 ```python Python
@@ -441,7 +457,11 @@ Test the agent:
 <CodeGroup>
 
 ```shell TypeScript
+# Node.js
 node index.ts "My cat Kitty does amazing things. Create a website about her."
+
+# Bun
+bun index.ts "My cat Kitty does amazing things. Create a website about her."
 ```
 
 ```shell Python


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds TypeScript code samples alongside existing Python samples across the OpenAI Agents SDK tutorials (basic and deployment variants). Covers installation commands for npm/pnpm/yarn/bun, agent setup, telemetry, and deployment steps. Also removes `set_tracing_disabled(True)` calls from all Python examples and fixes minor formatting (missing newlines at EOF).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c60b2c348ed663f44233ebbeb5179fce92e5ff45.</sup>
<!-- /MENDRAL_SUMMARY -->