### PR TITLE
docs: switch examples to idempotent creation methods

### DIFF
--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -113,46 +113,7 @@ When developing locally, you can also **log in to your workspace with Blaxel CLI
 
 </Accordion>
 
-<CodeGroup>
-
-```typescript TypeScript
-import { SandboxInstance } from "@blaxel/core";
-
-// Create a new sandbox
-const sandbox = await SandboxInstance.create({
-  name: "my-sandbox",
-  image: "blaxel/base-image:latest",   // public or custom image
-  memory: 4096,   // in MB
-  ports: [{ target: 3000, protocol: "HTTP" }],   // optional; ports to expose
-  labels: { env: "dev", project: "my-project" }, // optional; labels
-  region: "us-pdx-1"   // deployment region
-});
-```
-
-
-```python Python
-import asyncio
-from blaxel.core import SandboxInstance
-
-async def main():
-
-    # Create a new sandbox
-    sandbox = await SandboxInstance.create({
-      "name": "my-sandbox",
-      "image": "blaxel/base-image:latest",   # public or custom image
-      "memory": 4096,   # in MB
-      "ports": [{ "target": 3000 }],   # optional; ports to expose
-      "labels": {"env": "dev", "project": "my-project"},  # optional; labels
-      "region": "us-pdx-1"   # deployment region
-    })
-
-if __name__ == "__main__":
-    asyncio.run(main())
-```
-
-</CodeGroup>
-
-An alternative is to use the helper function `createIfNotExists()` (TypeScript) / `create_if_not_exists()` (Python). This helper function either retrieves an existing sandbox or creates a new one if it doesn't exist. Blaxel first checks for an existing sandbox with the provided `name` and either retrieves it or creates a new one using your specified configuration.
+The recommended pattern for sandbox creation is `createIfNotExists()` / `create_if_not_exists()`. Blaxel first checks for an existing sandbox with the provided `name` and either retrieves it or creates a new one using your specified configuration.
 
 <CodeGroup>
 
@@ -170,7 +131,6 @@ const sandbox = await SandboxInstance.createIfNotExists({
 });
 ```
 
-
 ```python Python
 import asyncio
 from blaxel.core import SandboxInstance
@@ -179,6 +139,44 @@ async def main():
 
     # Create sandbox if it doesn't exist
     sandbox = await SandboxInstance.create_if_not_exists({
+      "name": "my-sandbox",
+      "image": "blaxel/base-image:latest",   # public or custom image
+      "memory": 4096,   # in MB
+      "ports": [{ "target": 3000 }],   # optional; ports to expose
+      "labels": {"env": "dev", "project": "my-project"},  # optional; labels
+      "region": "us-pdx-1"   # deployment region
+    })
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+</CodeGroup>
+
+An alternative is to use `create()`, which raises an error when a sandbox with the specified name already exists:
+
+<CodeGroup>
+
+```typescript TypeScript
+import { SandboxInstance } from "@blaxel/core";
+
+const sandbox = await SandboxInstance.create({
+  name: "my-sandbox",
+  image: "blaxel/base-image:latest",   // public or custom image
+  memory: 4096,   // in MB
+  ports: [{ target: 3000, protocol: "HTTP" }],   // optional; ports to expose
+  labels: { env: "dev", project: "my-project" }, // optional; labels
+  region: "us-pdx-1"   // deployment region
+});
+```
+
+```python Python
+import asyncio
+from blaxel.core import SandboxInstance
+
+async def main():
+
+    sandbox = await SandboxInstance.create({
       "name": "my-sandbox",
       "image": "blaxel/base-image:latest",   # public or custom image
       "memory": 4096,   # in MB
@@ -275,8 +273,7 @@ You can also add optional labels for sandboxes. Labels are specified as key-valu
 <CodeGroup>
 
 ```typescript TypeScript
-// Create a new sandbox
-const sandbox = await SandboxInstance.create({
+const sandbox = await SandboxInstance.createIfNotExists({
   name: "my-sandbox",
   image: "blaxel/base-image:latest",   // public or custom image
   memory: 4096,   // in MB
@@ -287,8 +284,7 @@ const sandbox = await SandboxInstance.create({
 
 
 ```python Python
-# Create a new sandbox
-sandbox = await SandboxInstance.create({
+sandbox = await SandboxInstance.create_if_not_exists({
   "name": "my-sandbox",
   "image": "blaxel/base-image:latest",   # public or custom image
   "memory": 4096,   # in MB

--- a/Sandboxes/Preview-url.mdx
+++ b/Sandboxes/Preview-url.mdx
@@ -96,6 +96,8 @@ When developing locally, you can also **log in to your workspace with Blaxel CLI
 
 </Accordion>
 
+The recommended pattern for preview creation is `createIfNotExists()` / `create_if_not_exists()`. Blaxel first checks for an existing preview with the provided `name` and either returns it or creates a new one using your specified configuration.
+
 Create and manage a sandbox’s public preview URL:
 
 <CodeGroup>
@@ -105,7 +107,7 @@ import { SandboxInstance } from "@blaxel/core";
 
 const sandbox = await SandboxInstance.get("my-sandbox");
 // Create public preview
-const preview = await sandbox.previews.create({
+const preview = await sandbox.previews.createIfNotExists({
     metadata: { name: "app-preview" },
     spec: {
         port: 3000,
@@ -132,7 +134,7 @@ from blaxel.core import SandboxInstance
 sandbox = await SandboxInstance.get("my-sandbox")
 
 # Create public preview
-preview = await sandbox.previews.create({
+preview = await sandbox.previews.create_if_not_exists({
     "metadata": {"name": "app-preview"},
     "spec": {
         "port": 3000,
@@ -165,7 +167,7 @@ import { SandboxInstance } from "@blaxel/core";
 const sandbox = await SandboxInstance.get("my-sandbox");
 
 // Create private preview
-const preview = await sandbox.previews.create({
+const preview = await sandbox.previews.createIfNotExists({
     metadata: { name: "private-preview" },
     spec: {
       port: 3000,
@@ -191,7 +193,7 @@ from datetime import datetime, timedelta, UTC
 sandbox = await SandboxInstance.get("my-sandbox")
 
 # Create private preview
-preview = await sandbox.previews.create({
+preview = await sandbox.previews.create_if_not_exists({
     "metadata": {"name": "private-preview"},
     "spec": {
         "port": 3000,
@@ -211,6 +213,33 @@ async with httpx.AsyncClient() as client:
 
 </CodeGroup>
 
+An alternative is to use `create()`, which raises an error when a preview with the specified name already exists:
+
+<CodeGroup>
+```typescript TypeScript
+const preview = await sandbox.previews.create({
+    metadata: {
+        name: "preview-name"
+    },
+    spec: {
+        port: 443,
+        public: false
+    }
+})
+```
+```python Python
+preview = await sandbox.previews.create({
+    "metadata": {
+        "name": "preview-name"
+    },
+    "spec": {
+        "port": 443,
+        "public": False
+    }
+})
+```
+</CodeGroup>
+
 ### URL prefix
 
 You can customize the preview URL with a custom string prefix using the `prefixUrl` argument:
@@ -219,7 +248,7 @@ You can customize the preview URL with a custom string prefix using the `prefixU
 ```typescript TypeScript
 const sandbox = await SandboxInstance.get("my-sandbox");
 
-const preview = await sandbox.previews.create({
+const preview = await sandbox.previews.createIfNotExists({
     metadata: { name: "app-preview" },
     spec: {
         port: 3000,
@@ -232,7 +261,7 @@ const preview = await sandbox.previews.create({
 ```python Python
 sandbox = await SandboxInstance.get("my-sandbox")
 
-preview = await sandbox.previews.create({
+preview = await sandbox.previews.create_if_not_exists({
     "metadata": {"name": "app-preview"},
     "spec": {
         "port": 3000,
@@ -245,35 +274,6 @@ preview = await sandbox.previews.create({
 
 When using a prefix URL, the workspace name is automatically added to the prefix and included in the final structure for the preview URL - for example, `https://myprefix-workspace-xxx.preview.bl.run`.
 
-### Create if not exists
-
-Just like for sandboxes, this helper function either retrieves an existing preview or creates a new one if it doesn't exist. Blaxel first checks for an existing preview with the provided `name` and either retrieves it or creates a new one using your specified configuration.
-
-<CodeGroup>
-```typescript TypeScript
-const preview = await sandbox.previews.createIfNotExists({
-    metadata: {
-        name: "preview-name"
-    },
-    spec: {
-        port: 443,
-        public: false
-    }
-})
-```
-```python Python
-preview = await sandbox.previews.create_if_not_exists({
-    "metadata": {
-        "name": "preview-name"
-    },
-    "spec": {
-        "port": 443,
-        "public": False
-    }
-})
-```
-</CodeGroup>
-
 ## Custom domains
 
 To set up a custom domain for your sandbox preview:
@@ -283,9 +283,9 @@ To set up a custom domain for your sandbox preview:
 
 <CodeGroup>
 ```typescript TypeScript {8}
-const preview = await sandbox.previews.create({
+const preview = await sandbox.previews.createIfNotExists({
     metadata: {
-        name: "preview-custom-domain"
+        name: “preview-custom-domain”
     },
     spec: {
         port: 443,
@@ -295,14 +295,14 @@ const preview = await sandbox.previews.create({
 })
 ```
 ```python Python {8}
-preview = await sandbox.previews.create({
-    "metadata": {
-        "name": "preview-custom-domain"
+preview = await sandbox.previews.create_if_not_exists({
+    “metadata”: {
+        “name”: “preview-custom-domain”
     },
-    "spec": {
-        "port": 443,
-        "public": True,
-        "customDomain": "your.custom.domain.dev”
+    “spec”: {
+        “port”: 443,
+        “public”: True,
+        “customDomain”: “your.custom.domain.dev”
     }
 })
 ```

--- a/Sandboxes/Preview-url.mdx
+++ b/Sandboxes/Preview-url.mdx
@@ -285,24 +285,24 @@ To set up a custom domain for your sandbox preview:
 ```typescript TypeScript {8}
 const preview = await sandbox.previews.createIfNotExists({
     metadata: {
-        name: “preview-custom-domain”
+        name: "preview-custom-domain"
     },
     spec: {
         port: 443,
         public: false,
-        customDomain: ‘your.custom.domain.dev’
+        customDomain: "your.custom.domain.dev"
     }
 })
 ```
 ```python Python {8}
 preview = await sandbox.previews.create_if_not_exists({
-    “metadata”: {
-        “name”: “preview-custom-domain”
+    "metadata": {
+        "name": "preview-custom-domain"
     },
-    “spec”: {
-        “port”: 443,
-        “public”: True,
-        “customDomain”: “your.custom.domain.dev”
+    "spec": {
+        "port": 443,
+        "public": True,
+        "customDomain": "your.custom.domain.dev"
     }
 })
 ```

--- a/Sandboxes/Volumes.mdx
+++ b/Sandboxes/Volumes.mdx
@@ -20,11 +20,13 @@ To use a volume, attach it **when you create a sandbox** by passing an array of 
 
 Each configuration must include the `name` of the volume to attach and the `mountPath` where it will be accessible inside the sandbox's filesystem. The mount path **will override the existing content** of a directory.
 
+Use `createIfNotExists()` / `create_if_not_exists()` so that re-running your setup code is safe even if the sandbox already exists with the volume attached:
+
 <CodeGroup>
 ```typescript TypeScript
 import { SandboxInstance } from "@blaxel/core";
 
-const sandbox = await SandboxInstance.create({
+const sandbox = await SandboxInstance.createIfNotExists({
   name: "my-sandbox",
   image: "blaxel/nextjs:latest",
   memory: 4096,
@@ -41,7 +43,7 @@ const sandbox = await SandboxInstance.create({
 ```python Python
 from blaxel.core import SandboxInstance
 
-sandbox = await SandboxInstance.create({
+sandbox = await SandboxInstance.create_if_not_exists({
   "name": "my-sandbox",
   "image": "blaxel/nextjs:latest",
   "memory": 4096,

--- a/Sandboxes/best-practices.mdx
+++ b/Sandboxes/best-practices.mdx
@@ -66,6 +66,14 @@ The pattern works as follows:
 
 If using this pattern, implement a queuing system to coordinate sandbox usage and flag which sandboxes are in use. Without this, the same sandbox could be assigned to two tasks arriving at the same instant.
 
+## Use idempotent creation for sandboxes and preview URLs
+
+when creating sandboxes and preview URLs, use `createIfNotExists()` (TypeScript) / `create_if_not_exists()` (Python) instead of `create()`.
+
+These methods are idempotent and handle conflicts gracefully when the requested resource already exists. If it exists, they return it; if not, they create it.
+
+You should use `create()` only if you explicitly want an error to be raised when a sandbox or preview URL with the specified name already exists.
+
 ## Retry strategically in case of errors
 
 Blaxel returns [structured error responses](/troubleshooting/error-codes) in case of sandbox creation or connection failures. To handle these errors, we recommend the following strategy:

--- a/Sandboxes/best-practices.mdx
+++ b/Sandboxes/best-practices.mdx
@@ -68,7 +68,7 @@ If using this pattern, implement a queuing system to coordinate sandbox usage an
 
 ## Use idempotent creation for sandboxes and preview URLs
 
-when creating sandboxes and preview URLs, use `createIfNotExists()` (TypeScript) / `create_if_not_exists()` (Python) instead of `create()`.
+When creating sandboxes and preview URLs, use `createIfNotExists()` (TypeScript) / `create_if_not_exists()` (Python) instead of `create()`.
 
 These methods are idempotent and handle conflicts gracefully when the requested resource already exists. If it exists, they return it; if not, they create it.
 


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Promotes `createIfNotExists()` / `create_if_not_exists()` as the recommended idempotent creation pattern across sandbox and preview URL docs, demoting `create()` to an "alternative" that errors on conflict. Updates four docs files consistently and adds a new best-practices section.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit eba2d365951188c810e52ff4ee32205499d159e7.</sup>
<!-- /MENDRAL_SUMMARY -->