### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -2752,7 +2752,9 @@ components:
           example: true
         id:
           type: string
-          description: The id of the trigger
+          description: Identifier of the trigger. Optional — the server auto-generates
+            a unique id when one is not provided, and disambiguates duplicates within
+            a resource.
           example: trigger-1
         type:
           type: string


### PR DESCRIPTION
Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Expands the `id` field description in the controlplane API spec to clarify that the field is optional and that the server auto-generates and disambiguates IDs when not provided.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0c275abce8ac20f8de96e0f79ad8dda609f6d99a.</sup>
<!-- /MENDRAL_SUMMARY -->