### PR TITLE
fix: update install commands

### DIFF
--- a/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
+++ b/Tutorials/OpenAI-Agents-SDK-Deployment.mdx
@@ -42,22 +42,22 @@ In your project directory, install the [OpenAI Agents SDK with Blaxel support](h
 <CodeGroup>
 ```shell TypeScript (npm)
 npm init # if new project
-npm install @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express tsx typescript
+npm install @openai/agents-extensions @blaxel/core express @types/express tsx typescript
 ```
 
 ```shell TypeScript (pnpm)
 pnpm init # if new project
-pnpm install @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express tsx typescript
+pnpm install @openai/agents-extensions @blaxel/core express @types/express tsx typescript
 ```
 
 ```shell TypeScript (yarn)
 yarn init # if new project
-yarn add @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express tsx typescript
+yarn add @openai/agents-extensions @blaxel/core express @types/express tsx typescript
 ```
 
 ```shell TypeScript (bun)
 bun init -m --yes # if new project
-bun add @openai/agents @openai/agents-extensions @blaxel/core zod express @types/express
+bun add @openai/agents-extensions @blaxel/core express @types/express
 ```
 
 ```shell Python (pip)

--- a/Tutorials/OpenAI-Agents-SDK.mdx
+++ b/Tutorials/OpenAI-Agents-SDK.mdx
@@ -39,22 +39,22 @@ In your project directory, install the [OpenAI Agent SDK with Blaxel support](ht
 <CodeGroup>
 ```shell TypeScript (npm)
 npm init # if new project
-npm install @openai/agents @openai/agents-extensions @blaxel/core zod
+npm install @openai/agents-extensions @blaxel/core
 ```
 
 ```shell TypeScript (pnpm)
 pnpm init # if new project
-pnpm install @openai/agents @openai/agents-extensions @blaxel/core zod
+pnpm install @openai/agents-extensions @blaxel/core
 ```
 
 ```shell TypeScript (yarn)
 yarn init # if new project
-yarn add @openai/agents @openai/agents-extensions @blaxel/core zod
+yarn add @openai/agents-extensions @blaxel/core
 ```
 
 ```shell TypeScript (bun)
 bun init -m --yes # if new project
-bun add @openai/agents @openai/agents-extensions @blaxel/core zod
+bun add @openai/agents-extensions @blaxel/core
 ```
 
 ```shell Python


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes `@openai/agents` and `zod` from install commands across all package managers in both tutorial docs, reflecting that `@openai/agents-extensions` now handles these as peer/transitive dependencies.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 20567ffa2921df416a45c116faadec42fdce3bc7.</sup>
<!-- /MENDRAL_SUMMARY -->