### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -146,6 +146,10 @@ components:
           description: Countries
           items:
             $ref: '#/components/schemas/Country'
+        detectedRegion:
+          type: string
+          description: Auto-detected closest region based on viewer geolocation (from
+            CloudFront headers). Empty when geo headers are not available.
         privateLocations:
           type: array
           description: Private locations managed with blaxel operator


### PR DESCRIPTION
Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `detectedRegion` field to the API schema, exposing the auto-detected closest region derived from CloudFront geolocation headers.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6ee29eba07d3a9f3f0f68d5407846148a08ae7a5.</sup>
<!-- /MENDRAL_SUMMARY -->