### PR TITLE
docs: update changelog

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -71,6 +71,14 @@ Updated platform [error messages](/troubleshooting/error-codes) with additional 
 
 </Update>
 
+<Update label="2026-04-18">
+
+### Deploy multiple jobs from a single image
+
+Build a job image once and [reuse it across multiple job definitions](/Jobs/Deploy-shared-image) with different memory, disk, or region profiles, without rebuilding.
+
+</Update>
+
 <Update label="2026-04-15">
 
 ### Cross-workspace image sharing


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a changelog entry for the "Deploy multiple jobs from a single image" feature released on 2026-04-18, linking to the `/Jobs/Deploy-shared-image` documentation page.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b12b838a48bfa534488098b57fa65f69f5f10637.</sup>
<!-- /MENDRAL_SUMMARY -->