### PR TITLE
feat: add info and config for ephemeral volumes

### DIFF
--- a/Jobs/Deploy-a-job.mdx
+++ b/Jobs/Deploy-a-job.mdx
@@ -354,3 +354,13 @@ tasks = [
         - `tasks = [{my_arg="my_value"}]` containing a list of task to execute at each occurrence of the cron (default value is one task, without arguments)
 
 A private HTTP endpoint to launch job executions is always available by default, even if you don't define a trigger in this file. You can launch a job execution by sending a POST request with the correct job and workspace arguments to `https://api.blaxel.ai/v0/jobs/my-job/executions?workspace=my-workspace`.
+
+## Ephemeral volumes
+
+Ephemeral volumes are temporary disk-backed storage attached to a job at startup and automatically destroyed when the job completes. They use NVMe storage on the host, making them significantly faster than standard volumes.
+
+Ephemeral volumes have separate quotas from persistent volumes. Limits depend on your plan.
+
+<Note>
+  Ephemeral volumes are only available for jobs. Sandboxes and agents should use persistent volumes instead.
+</Note>

--- a/Jobs/Deploy-a-job.mdx
+++ b/Jobs/Deploy-a-job.mdx
@@ -357,9 +357,7 @@ A private HTTP endpoint to launch job executions is always available by default,
 
 ## Ephemeral volumes
 
-Ephemeral volumes are temporary disk-backed storage attached to a job at startup and automatically destroyed when the job completes. They use NVMe storage on the host, making them significantly faster than standard volumes.
-
-Ephemeral volumes have separate quotas from persistent volumes. Limits depend on your plan.
+Ephemeral volumes are temporary disk-backed storage attached to a job at startup and automatically destroyed when the job completes. Ephemeral volumes have separate quotas from persistent volumes. Limits depend on your plan.
 
 <Note>
   Ephemeral volumes are only available for jobs. Sandboxes and agents should use persistent volumes instead.

--- a/deployment-reference.mdx
+++ b/deployment-reference.mdx
@@ -77,12 +77,16 @@ The format of Blaxel's configuration file is described below.
 # volume name
 # name = "my-volume"
 
+# volume type (only for resource type="job")
+# possible values: ["ephemeral"]
+# type = "ephemeral"
+
 # volume mount path
 # for resource type="agent" and "sandbox", attaches persistent storage
 # for resource type="job", attaches ephemeral storage
 # mountPath = "/data"
 
-# volume size in MB (only valid for resource type="job" and ephemeral storage)
+# volume size in MB (only valid for resource type="job" and volume type="ephemeral")
 # sizeMb = 10240
 
 # volume templates directory (only valid for resource type="volume-template")
@@ -90,10 +94,6 @@ The format of Blaxel's configuration file is described below.
 
 # volume default size in MB (only valid for resource type="volume-template")
 # defaultSize = 1024
-
-# volume type (only for resource type="job")
-# possible values: ["ephemeral"]
-# type = "ephemeral"
 
 # job trigger (optional)
 # [[triggers]]

--- a/deployment-reference.mdx
+++ b/deployment-reference.mdx
@@ -21,12 +21,12 @@ The format of Blaxel's configuration file is described below.
 # requires registry credentials in .docker/config.json or via bl push flags
 # image = "docker.io/myuser/my-sandbox:latest"
 
-# public access to resource (only for resource type="agent")
+# public access to resource (only valid for resource type="agent")
 # possible values: [true, false]
 # defaults to false
 # public = false
 
-# deployment region (optional, for resource type="agent" or resource type="function")
+# deployment region (optional, for resource type="agent", "function")
 # pins the resource to a specific region instead of global distribution
 # required when attaching volumes to an agent
 # region = "us-pdx-1"
@@ -53,7 +53,7 @@ The format of Blaxel's configuration file is described below.
 
 # environment variables (optional)
 # [env]
-# key-value paris
+# key-value pairs
 # MY_VAR = "my-value"
 
 # runtime configuration (optional)
@@ -68,9 +68,9 @@ The format of Blaxel's configuration file is described below.
 # timeout = 900
 
 # maximum number of retries
-# maxRetries=0
+# maxRetries = 0
 
-# volumes (optional, for resource type="agent" and resource type="sandbox")
+# volumes (optional, for resource type="agent", "sandbox", "volume-template", "job")
 # attaches persistent storage to the resource
 # the resource must be pinned to the same region as the volume
 # [[volumes]]
@@ -78,13 +78,22 @@ The format of Blaxel's configuration file is described below.
 # name = "my-volume"
 
 # volume mount path
+# for resource type="agent" and "sandbox", attaches persistent storage
+# for resource type="job", attaches ephemeral storage
 # mountPath = "/data"
 
-# volume templates directory (only for resource type="volume-template")
+# volume size in MB (only valid for resource type="job" and ephemeral storage)
+# sizeMb = 10240
+
+# volume templates directory (only valid for resource type="volume-template")
 # directory = "."
 
-# volume default size in MB (only for resource type="volume-template")
+# volume default size in MB (only valid for resource type="volume-template")
 # defaultSize = 1024
+
+# volume type (only for resource type="job")
+# possible values: ["ephemeral"]
+# type = "ephemeral"
 
 # job trigger (optional)
 # [[triggers]]
@@ -92,16 +101,16 @@ The format of Blaxel's configuration file is described below.
 # id = "my-trigger"
 
 # trigger type
-# possible values: ["schedule", "http", "http-async"]
-# "schedule" trigger (only valid for resource type="job")
-# type = "schedule"
+# possible values: ["cron", "http", "http-async"]
+# "cron" trigger (only valid for resource type="job")
+# type = "cron"
 # "http" trigger (only valid for resource type="agent" and resource type="function")
 # type = "http"
 # "http-async" trigger (only valid for resource type="agent")
 # type = "http-async"
 
 # [[triggers.configuration]]
-# cron expression (only for trigger type="schedule")
+# cron expression (only for trigger type="cron")
 # schedule = "0 * * * *"
 
 # endpoint URL (only for trigger type="http" and trigger type="http-async")


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds documentation for ephemeral volumes in jobs: a new prose section in Deploy-a-job.mdx, and updates to deployment-reference.mdx with new `type` and `sizeMb` fields under `[[volumes]]`, corrected trigger type name (`schedule` → `cron`), and minor copy fixes ("paris" → "pairs", spacing around `maxRetries`).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 58e3d649c9d1a33257878008c91acb4503af256b.</sup>
<!-- /MENDRAL_SUMMARY -->