### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -3378,6 +3378,41 @@ components:
           - forbidden_reserved
           - forbidden_blaxel
           - forbidden_v_prefix
+    WorkspaceHipaaInfo:
+      type: object
+      description: HIPAA compliance state for a workspace. `accountEnabled` mirrors
+        the account-level `hipaa_compliance` addon (set server-side from operator
+        tooling and Stripe billing events). `unsafe` records a per-workspace opt-out
+        toggled from workspace settings; absent when the account does not have the
+        addon.
+      properties:
+        accountEnabled:
+          type: boolean
+          description: True when the parent account has the HIPAA compliance addon
+            active. Set server-side from operator tooling and Stripe billing events;
+            cannot be changed from workspace settings.
+        unsafe:
+          $ref: '#/components/schemas/WorkspaceHipaaUnsafe'
+    WorkspaceHipaaUnsafe:
+      type: object
+      description: Per-workspace HIPAA opt-out record. Toggled from workspace settings;
+        the backend stamps `updatedBy` and `updatedAt`.
+      properties:
+        enabled:
+          type: boolean
+          description: True marks this workspace as HIPAA-unsafe (NOT compliant),
+            overriding the account-level addon. False marks the workspace as HIPAA
+            compliant.
+        updatedAt:
+          type: string
+          description: RFC3339 timestamp when the opt-out was last toggled. Stamped
+            server-side.
+          readOnly: true
+        updatedBy:
+          type: string
+          description: User id (sub) of the actor that last toggled this opt-out.
+            Stamped server-side.
+          readOnly: true
     WorkspaceRuntime:
       type: object
       description: Runtime configuration for the workspace infrastructure


### PR DESCRIPTION
Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds two new OpenAPI schema components (`WorkspaceHipaaInfo` and `WorkspaceHipaaUnsafe`) to the controlplane API spec, documenting HIPAA compliance state at the account and workspace levels.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 73d4448a81e3a837af0610670ce53d60813fb484.</sup>
<!-- /MENDRAL_SUMMARY -->