### PR TITLE
docs: clarify effect of "bl push"

### DIFF
--- a/Agents/Deploy-an-agent.mdx
+++ b/Agents/Deploy-an-agent.mdx
@@ -46,7 +46,7 @@ Run the following command to build and deploy a local agent on Blaxel:
 bl deploy
 ```
 
-You can alternatively use `bl push` to build and push the agent container image to the Blaxel registry without creating or updating the agent deployment. This is useful for preparing images in advance.
+You can alternatively use `bl push` to build and push the agent container image to the Blaxel registry. `bl push` only publishes the image; it does not update existing sandbox deployments or restart running processes. This is useful for preparing images in advance.
 
 <Note>When making a deployment using Blaxel CLI (`bl deploy`), the new traffic routing depends on the `--traffic` option. Without this option specified, Blaxel will automatically deploy the new revision with full traffic (100%) if the previous deployment was the latest revision. Otherwise, it will create the revision without deploying it (0% traffic).</Note>
 

--- a/Agents/Deploy-an-agent.mdx
+++ b/Agents/Deploy-an-agent.mdx
@@ -46,7 +46,7 @@ Run the following command to build and deploy a local agent on Blaxel:
 bl deploy
 ```
 
-You can alternatively use `bl push` to build and push the agent container image to the Blaxel registry. `bl push` only publishes the image; it does not update existing sandbox deployments or restart running processes. This is useful for preparing images in advance.
+You can alternatively use `bl push` to build and push the agent container image to the Blaxel registry. `bl push` only publishes the image; it does not create a new sandbox deployment, update existing deployments, or restart running processes. This is useful for preparing images in advance.
 
 <Note>When making a deployment using Blaxel CLI (`bl deploy`), the new traffic routing depends on the `--traffic` option. Without this option specified, Blaxel will automatically deploy the new revision with full traffic (100%) if the previous deployment was the latest revision. Otherwise, it will create the revision without deploying it (0% traffic).</Note>
 

--- a/Agents/Deploy-dockerfile.mdx
+++ b/Agents/Deploy-dockerfile.mdx
@@ -103,7 +103,7 @@ When a Dockerfile is present at the root of your project, Blaxel will use it to 
 bl deploy
 ```
 
-You can alternatively use `bl push` to build and push the container image to the Blaxel registry without creating or updating the deployment.
+You can alternatively use `bl push` to build and push the container image to the Blaxel registry. `bl push` only publishes the image; it does not update existing sandbox deployments or restart running processes.
 
 ## Deploy multiple resources with shared files
 

--- a/Agents/Deploy-dockerfile.mdx
+++ b/Agents/Deploy-dockerfile.mdx
@@ -103,7 +103,7 @@ When a Dockerfile is present at the root of your project, Blaxel will use it to 
 bl deploy
 ```
 
-You can alternatively use `bl push` to build and push the container image to the Blaxel registry. `bl push` only publishes the image; it does not update existing sandbox deployments or restart running processes.
+You can alternatively use `bl push` to build and push the container image to the Blaxel registry. `bl push` only publishes the image; it does not create a new sandbox deployment, update existing deployments, or restart running processes.
 
 ## Deploy multiple resources with shared files
 

--- a/Functions/Deploy-a-function.mdx
+++ b/Functions/Deploy-a-function.mdx
@@ -73,7 +73,7 @@ Run the following command to build and deploy the MCP server on Blaxel:
 ```bash
 bl deploy
 ```
-You can alternatively use `bl push` to build and push the MCP container image to the Blaxel registry without creating or updating the deployment. This is useful for preparing images in advance.
+You can alternatively use `bl push` to build and push the MCP container image to the Blaxel registry. `bl push` only publishes the image; it does not update existing sandbox deployments or restart running processes. This is useful for preparing images in advance.
 
 
 You can now [connect to the MCP server](/Functions/Invoke-functions) either from an agent on Blaxel (using the Blaxel SDK), or from an external client that supports HTTP.

--- a/Functions/Deploy-a-function.mdx
+++ b/Functions/Deploy-a-function.mdx
@@ -73,7 +73,7 @@ Run the following command to build and deploy the MCP server on Blaxel:
 ```bash
 bl deploy
 ```
-You can alternatively use `bl push` to build and push the MCP container image to the Blaxel registry. `bl push` only publishes the image; it does not update existing sandbox deployments or restart running processes. This is useful for preparing images in advance.
+You can alternatively use `bl push` to build and push the MCP container image to the Blaxel registry. `bl push` only publishes the image; it does not create a new sandbox deployment, update existing deployments, or restart running processes.  This is useful for preparing images in advance.
 
 
 You can now [connect to the MCP server](/Functions/Invoke-functions) either from an agent on Blaxel (using the Blaxel SDK), or from an external client that supports HTTP.

--- a/Jobs/Deploy-a-job.mdx
+++ b/Jobs/Deploy-a-job.mdx
@@ -39,7 +39,7 @@ Run the following command to build and deploy a local job on Blaxel:
 bl deploy
 ```
 
-You can alternatively use `bl push` to build and push the job container image to the Blaxel registry. `bl push` only publishes the image; it does not update existing sandbox deployments or restart running processes. This is useful for preparing images in advance.
+You can alternatively use `bl push` to build and push the job container image to the Blaxel registry. `bl push` only publishes the image; it does not create a new sandbox deployment, update existing deployments, or restart running processes. This is useful for preparing images in advance.
 
 
 ## Run a job

--- a/Jobs/Deploy-a-job.mdx
+++ b/Jobs/Deploy-a-job.mdx
@@ -39,7 +39,7 @@ Run the following command to build and deploy a local job on Blaxel:
 bl deploy
 ```
 
-You can alternatively use `bl push` to build and push the job container image to the Blaxel registry without creating or updating the deployment. This is useful for preparing images in advance.
+You can alternatively use `bl push` to build and push the job container image to the Blaxel registry. `bl push` only publishes the image; it does not update existing sandbox deployments or restart running processes. This is useful for preparing images in advance.
 
 
 ## Run a job

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -212,7 +212,7 @@ It is also possible to create a sandbox via the Blaxel CLI or the Blaxel Console
     The project directory contains the Blaxel configuration file `blaxel.toml`, which can be further customized to suit your sandbox deployment requirements, by modifying the base image, memory, environment, etc. [`Learn more about the blaxel.toml file`](/deployment-reference).
 
     <Tip>
-      Running `bl deploy` here also saves the image to be reused later. As an alternative, you can use `bl push` to push the image to Blaxel's registry. `bl push` only publishes the image; it does not update existing sandbox deployments or restart running processes.
+      Running `bl deploy` here also saves the image to be reused later. As an alternative, you can use `bl push` to push the image to Blaxel's registry. `bl push` only publishes the image; it does not create a new sandbox deployment, update existing deployments, or restart running processes.
     </Tip>
   </Tab>
   <Tab title="Console">

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -212,7 +212,7 @@ It is also possible to create a sandbox via the Blaxel CLI or the Blaxel Console
     The project directory contains the Blaxel configuration file `blaxel.toml`, which can be further customized to suit your sandbox deployment requirements, by modifying the base image, memory, environment, etc. [`Learn more about the blaxel.toml file`](/deployment-reference).
 
     <Tip>
-      Running `bl deploy` here also saves the image to be reused later. As an alternative, you can use `bl push` to push the image to Blaxel's registry without deploying it.
+      Running `bl deploy` here also saves the image to be reused later. As an alternative, you can use `bl push` to push the image to Blaxel's registry. `bl push` only publishes the image; it does not update existing sandbox deployments or restart running processes.
     </Tip>
   </Tab>
   <Tab title="Console">

--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -20,7 +20,7 @@ When you create a sandbox from an image, Blaxel provisions a new instance with a
 
 ### How sandbox images work
 
-1. **Initial setup**: Follow this guide to create your sandbox image for the first time. Use `bl push` to publish the image to Blaxel's registry (existing sandboxes and running processes are unaffected), or `bl deploy` to push the image and also create a sandbox from it.
+1. **Initial setup**: Follow this guide to create your sandbox image for the first time. Use `bl push` to publish the image to Blaxel's registry without creating a new sandbox or affecting existing sandboxes, or `bl deploy` to push the image and also create a sandbox from it.
 2. **Build phase**: Your Dockerfile is used to create a container with all required tools and configurations.
 3. **Initialization phase**: The sandbox API is injected and startup commands are executed.
 4. **Instantiation**: New sandboxes can be spawned from this image in seconds.

--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -20,7 +20,7 @@ When you create a sandbox from an image, Blaxel provisions a new instance with a
 
 ### How sandbox images work
 
-1. **Initial setup**: Follow this guide to create your sandbox image for the first time. Use `bl push` to push the image to Blaxel, or `bl deploy` to push the image and also create a sandbox from it.
+1. **Initial setup**: Follow this guide to create your sandbox image for the first time. Use `bl push` to publish the image to Blaxel's registry (existing sandboxes and running processes are unaffected), or `bl deploy` to push the image and also create a sandbox from it.
 2. **Build phase**: Your Dockerfile is used to create a container with all required tools and configurations.
 3. **Initialization phase**: The sandbox API is injected and startup commands are executed.
 4. **Instantiation**: New sandboxes can be spawned from this image in seconds.


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR clarifies the behavior of `bl push` across six documentation files, explicitly stating that it only publishes the image without creating new sandbox deployments, updating existing ones, or restarting running processes.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e2fe5d2d1cb7daeec65f770eba3af8da05d0571c.</sup>
<!-- /MENDRAL_SUMMARY -->