### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -8,6 +8,17 @@ components:
       required: false
       schema:
         type: string
+    PaginationAnchor:
+      description: Start from a known pagination boundary. `end` is only supported
+        for `createdAt:desc` listings and returns the oldest page directly without
+        walking every cursor from the first page.
+      in: query
+      name: anchor
+      required: false
+      schema:
+        enum:
+        - end
+        type: string
     PaginationCursor:
       description: Opaque cursor returned by a previous response's meta.nextCursor.
         Only valid for the same query (workspace + filters); the server rejects cursors
@@ -3626,6 +3637,7 @@ paths:
       - $ref: '#/components/parameters/PaginationLimit'
       - $ref: '#/components/parameters/PaginationSort'
       - $ref: '#/components/parameters/PaginationQuery'
+      - $ref: '#/components/parameters/PaginationAnchor'
       responses:
         "200":
           content:
@@ -4079,6 +4091,7 @@ paths:
       - $ref: '#/components/parameters/PaginationLimit'
       - $ref: '#/components/parameters/PaginationSort'
       - $ref: '#/components/parameters/PaginationQuery'
+      - $ref: '#/components/parameters/PaginationAnchor'
       responses:
         "200":
           content:
@@ -4479,6 +4492,7 @@ paths:
       - $ref: '#/components/parameters/PaginationLimit'
       - $ref: '#/components/parameters/PaginationSort'
       - $ref: '#/components/parameters/PaginationQuery'
+      - $ref: '#/components/parameters/PaginationAnchor'
       responses:
         "200":
           content:
@@ -5447,6 +5461,7 @@ paths:
       - $ref: '#/components/parameters/PaginationLimit'
       - $ref: '#/components/parameters/PaginationSort'
       - $ref: '#/components/parameters/PaginationQuery'
+      - $ref: '#/components/parameters/PaginationAnchor'
       responses:
         "200":
           content:
@@ -5857,6 +5872,7 @@ paths:
       - $ref: '#/components/parameters/PaginationLimit'
       - $ref: '#/components/parameters/PaginationSort'
       - $ref: '#/components/parameters/PaginationQuery'
+      - $ref: '#/components/parameters/PaginationAnchor'
       responses:
         "200":
           content:
@@ -6231,6 +6247,7 @@ paths:
       - $ref: '#/components/parameters/PaginationLimit'
       - $ref: '#/components/parameters/PaginationSort'
       - $ref: '#/components/parameters/PaginationQuery'
+      - $ref: '#/components/parameters/PaginationAnchor'
       responses:
         "200":
           content:
@@ -6440,6 +6457,7 @@ paths:
       - $ref: '#/components/parameters/PaginationLimit'
       - $ref: '#/components/parameters/PaginationSort'
       - $ref: '#/components/parameters/PaginationQuery'
+      - $ref: '#/components/parameters/PaginationAnchor'
       responses:
         "200":
           content:
@@ -7577,6 +7595,7 @@ paths:
       - $ref: '#/components/parameters/PaginationLimit'
       - $ref: '#/components/parameters/PaginationSort'
       - $ref: '#/components/parameters/PaginationQuery'
+      - $ref: '#/components/parameters/PaginationAnchor'
       responses:
         "200":
           content:


### PR DESCRIPTION
Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new `PaginationAnchor` query parameter to the OpenAPI spec and applies it to 8 list endpoints. The parameter accepts only `end` as a valid enum value, enabling direct access to the last page for `createdAt:desc` sorted listings.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 32114a83e968ea3bbf2fc1d4b6da71da8244c2c7.</sup>
<!-- /MENDRAL_SUMMARY -->