### PR TITLE
Fix sandbox process timeout docs

### DIFF
--- a/Sandboxes/Processes.mdx
+++ b/Sandboxes/Processes.mdx
@@ -180,7 +180,7 @@ const process = await sandbox.process.exec({
   name: "build-process",
   command: "npm run build",
   waitForCompletion: true,
-  timeout: 60000 // 60 seconds
+  timeout: 60 // 60 seconds
 });
 ```
 
@@ -189,13 +189,13 @@ process = await sandbox.process.exec({
   "name": "build-process",
   "command": "npm run build",
   "wait_for_completion": True,
-  "timeout": 60000  # 60 seconds
+  "timeout": 60  # 60 seconds
 })
 ```
 
 </CodeGroup>
 
-When waiting for completion, the process execution object will contain a `.logs` field with the [combined `stdout` and `stderr` output as a string](/Sandboxes/Log-streaming). Also, notice the `timeout` parameter which allows to set a timeout duration on the process.
+When waiting for completion, the process execution object will contain a `.logs` field with the [combined `stdout` and `stderr` output as a string](/Sandboxes/Log-streaming). Also, notice the `timeout` parameter which allows you to set the process timeout duration in seconds.
 
 <Warning>When using `waitForCompletion`, Blaxel enforces a **timeout limit of 60 seconds**. Don't set your timeout longer than this. For longer waiting periods, use the process-watching option described below.</Warning>
 

--- a/Tutorials/Tailscale.mdx
+++ b/Tutorials/Tailscale.mdx
@@ -123,7 +123,7 @@ await sandbox.process.exec({
   name: "install-deps",
   command: "apk add --no-cache tailscale iptables",
   waitForCompletion: true,
-  timeout: 60000,
+  timeout: 60, // 60 seconds
 });
 
 // 3. Start the tailscaled daemon in the background
@@ -143,7 +143,7 @@ const up = await sandbox.process.exec({
   command: `tailscale up --authkey=$TS_AUTHKEY --hostname=${SANDBOX_NAME} --ssh`,
   env: { TS_AUTHKEY },
   waitForCompletion: true,
-  timeout: 30000,
+  timeout: 30, // 30 seconds
 });
 console.log("tailscale up:", up.logs);
 
@@ -152,7 +152,7 @@ const ip = await sandbox.process.exec({
   name: "tailscale-ip",
   command: "tailscale ip",
   waitForCompletion: true,
-  timeout: 10000,
+  timeout: 10, // 10 seconds
 });
 console.log("Tailscale IP:", ip.logs?.trim());
 ```
@@ -177,7 +177,7 @@ async def setup_tailscale():
         "name": "install-deps",
         "command": "apk add --no-cache tailscale iptables",
         "wait_for_completion": True,
-        "timeout": 60000,
+        "timeout": 60,  # 60 seconds
     })
 
     # 3. Start the tailscaled daemon in the background
@@ -197,7 +197,7 @@ async def setup_tailscale():
         "command": f"tailscale up --authkey=$TS_AUTHKEY --hostname={SANDBOX_NAME} --ssh",
         "env": {"TS_AUTHKEY": TS_AUTHKEY},
         "wait_for_completion": True,
-        "timeout": 30000,
+        "timeout": 30,  # 30 seconds
     })
     print("tailscale up:", up.logs)
 
@@ -206,7 +206,7 @@ async def setup_tailscale():
         "name": "tailscale-ip",
         "command": "tailscale ip",
         "wait_for_completion": True,
-        "timeout": 10000,
+        "timeout": 10,  # 10 seconds
     })
     print("Tailscale IP:", ip.logs.strip())
 


### PR DESCRIPTION
## Summary
- Fix sandbox `process.exec` timeout examples to use seconds.
- Clarify that the timeout value is in seconds.

## Verification
- Checked current SDK/backend behavior: timeout is seconds-based.
- `rg` found no remaining 10000/30000/60000 process timeout examples in touched docs areas.
- `git diff --check -- Sandboxes/Processes.mdx Tutorials/Tailscale.mdx`
