### PR TITLE
docs: clarify proxy HTTP2 client support

### DIFF
--- a/Sandboxes/Proxy.mdx
+++ b/Sandboxes/Proxy.mdx
@@ -167,12 +167,15 @@ import urllib.parse
 import urllib3
 
 proxy_url = os.environ["HTTPS_PROXY"]
-proxy_auth = urllib.parse.unquote(
-    urllib.parse.urlsplit(proxy_url).netloc.rsplit("@", 1)[0]
-)
+_parsed = urllib.parse.urlsplit(proxy_url)
+_userinfo = _parsed.netloc.rsplit("@", 1)
+proxy_kwargs = {}
+if len(_userinfo) == 2:
+    proxy_auth = urllib.parse.unquote(_userinfo[0])
+    proxy_kwargs["proxy_headers"] = urllib3.make_headers(proxy_basic_auth=proxy_auth)
 http = urllib3.ProxyManager(
     proxy_url,
-    proxy_headers=urllib3.make_headers(proxy_basic_auth=proxy_auth),
+    **proxy_kwargs,
     cert_reqs="CERT_REQUIRED",
     ca_certs=os.environ.get("SSL_CERT_FILE"),
 )

--- a/Sandboxes/Proxy.mdx
+++ b/Sandboxes/Proxy.mdx
@@ -181,7 +181,7 @@ http = urllib3.ProxyManager(
 )
 resp = http.request(
     "GET",
-    "https://storage.googleapis.com/storage/v1/b/my-bucket/o",
+    "https://api.stripe.com/v1/charges"
 )
 print(resp.status, resp.data.decode())
 ```

--- a/Sandboxes/Proxy.mdx
+++ b/Sandboxes/Proxy.mdx
@@ -199,7 +199,6 @@ print(resp.status, resp.data.decode())
 
 The proxy supports HTTP/2 and gRPC. Clients that previously required HTTP/1.1 workarounds now work without any flags or downgrades:
 
-- `gcsfuse` and other Google Cloud clients (no need for `--client-protocol=http1`)
 - gRPC SDKs in Go, Python (`grpcio`), and Node (`@grpc/grpc-js`)
 - `curl --http2`
 - Go `net/http` (HTTP/2 is the default)

--- a/Sandboxes/Proxy.mdx
+++ b/Sandboxes/Proxy.mdx
@@ -31,7 +31,7 @@ When a sandbox is created with a proxy config, Blaxel:
 5. Injects configured headers and body fields, resolving `{{SECRET:name}}` placeholders server-side
 6. Adds an `X-Blaxel-Request-Id` header to every proxied request for tracing
 
-Standard HTTP clients work transparently: `curl`, `wget`, `git`, `pip`, `npm`, Node.js `https`, Python `requests`, etc.
+Common CLI tools and high-level clients — `curl`, `pip`, `npm`, `git`, Python `requests`, Python `httpx` — work transparently via the injected `HTTP_PROXY` / `HTTPS_PROXY` / `SSL_CERT_FILE` environment variables. Lower-level libraries such as direct `urllib3` may require explicit proxy auth and CA configuration.
 
 <Note>
 Localhost (`127.0.0.1`), private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), `169.254.169.254`, `.local`, and `.internal` are always bypassed automatically.
@@ -141,14 +141,14 @@ When proxy is configured, the sandbox automatically has:
 | Variable | Purpose |
 |---|---|
 | `HTTP_PROXY` | Proxy URL for HTTP traffic |
-| `HTTPS_PROXY` | Proxy URL for HTTPS traffic |
+| `HTTPS_PROXY` | Proxy URL for HTTPS traffic. The value normally uses an `http://...` proxy URL; HTTPS destinations are tunneled with CONNECT. |
 | `NO_PROXY` | Comma-separated bypass list (always includes localhost, private ranges) |
 | `NODE_EXTRA_CA_CERTS` | Path to CA cert for Node.js TLS verification |
 | `SSL_CERT_FILE` | Path to CA cert for other TLS clients (`curl`, Python, etc.) |
 
 ## CLI tool compatibility
 
-When proxy is enabled, the following tools work transparently inside the sandbox with no extra configuration:
+When proxy is enabled, common CLI tools and high-level clients work transparently inside the sandbox with no extra configuration:
 
 | Tool | Protocol | Notes |
 |---|---|---|
@@ -157,7 +157,31 @@ When proxy is enabled, the following tools work transparently inside the sandbox
 | `pip` / `pip3` | HTTPS | Automatic |
 | `npm` / `npx` | HTTPS | Automatic |
 | Python `requests` | HTTPS | Automatic via env vars |
-| Node.js `https` | HTTPS | Automatic via `HTTPS_PROXY` + `NODE_EXTRA_CA_CERTS` env vars |
+| Python `httpx` | HTTPS | Automatic via env vars |
+
+Python's stdlib `urllib.request` works fine with an **HTTP** proxy (`HTTP_PROXY=http://...`), which is the normal pattern; it does not support HTTPS proxies (TLS-to-proxy) without monkey-patching, and we do not recommend it for that use case. Use `urllib3.ProxyManager` if you need explicit control:
+
+```python
+import os
+import urllib.parse
+import urllib3
+
+proxy_url = os.environ["HTTPS_PROXY"]
+proxy_auth = urllib.parse.unquote(
+    urllib.parse.urlsplit(proxy_url).netloc.rsplit("@", 1)[0]
+)
+http = urllib3.ProxyManager(
+    proxy_url,
+    proxy_headers=urllib3.make_headers(proxy_basic_auth=proxy_auth),
+    cert_reqs="CERT_REQUIRED",
+    ca_certs=os.environ.get("SSL_CERT_FILE"),
+)
+resp = http.request(
+    "GET",
+    "https://storage.googleapis.com/storage/v1/b/my-bucket/o",
+)
+print(resp.status, resp.data.decode())
+```
 
 ## Behavior details
 
@@ -167,6 +191,27 @@ When proxy is enabled, the following tools work transparently inside the sandbox
 - **Body merge**: Injected body fields are merged into the outbound JSON payload. User-sent fields take precedence if there's a key collision
 - **Tracing**: Every proxied request gets an `X-Blaxel-Request-Id` header for observability
 - **Local traffic**: Requests to `localhost` / `127.0.0.1` are never routed through the proxy
+
+### HTTP/2 and gRPC through CONNECT
+
+The MITM proxy advertises `h2, http/1.1` to the client and to the upstream origin during the inner TLS handshake established after CONNECT. It speaks HTTP/2 upstream when both sides support it and falls back to HTTP/1.1 transparently when they do not. Negotiation happens per inner TLS handshake.
+
+HTTP/2 support lives **inside** the CONNECT tunnel only. The client connects to the proxy with an HTTP proxy URL (`HTTP_PROXY=http://...` or `HTTPS_PROXY=http://...`), sends a cleartext CONNECT, and then negotiates h2 on the inner TLS session terminated by the MITM proxy. RFC 8441 / extended CONNECT is not supported: do not use `HTTPS_PROXY=https://...` to negotiate HTTP/2 to the proxy itself.
+
+gRPC unary, server-streaming, client-streaming, and bidirectional RPCs flow through the proxy. gRPC trailers such as `grpc-status` and `grpc-message` are preserved, and header injection is applied per stream rather than per connection.
+
+Identity headers such as `X-Blaxel-Sandbox-Id` and the resolved routing rules are bound at CONNECT time. All h2 streams multiplexed over the same CONNECT share that identity and rule set. Config changes mid-connection apply to new CONNECTs, not in-flight streams.
+
+Clients that previously needed HTTP/1.1 workarounds can now use HTTP/2 normally:
+
+- `gcsfuse` (the Go GCS client uses h2 by default; `--client-protocol=http1` is no longer required)
+- gRPC SDKs for Go, Python `grpcio`, and Node `@grpc/grpc-js`
+- Go `net/http` with `Transport.ForceAttemptHTTP2 = true` (the default since Go 1.6)
+- `curl --http2`
+
+Body injection requires buffering the request body. Lower-level `bodyInjections` rules (shown as `body` in the sandbox SDK examples) are skipped when the request body is long-lived or cannot be buffered, such as gRPC streaming RPCs or chunked uploads. Header injection has no such limitation.
+
+Browsers and Go h2 clients often coalesce many requests onto one TLS connection. Per-stream audit logging is unchanged, with one line per request, but operators should expect fewer and busier MITM connections in metrics dashboards.
 
 ## Full example: agent sandbox with proxy + firewall
 

--- a/Sandboxes/Proxy.mdx
+++ b/Sandboxes/Proxy.mdx
@@ -31,7 +31,7 @@ When a sandbox is created with a proxy config, Blaxel:
 5. Injects configured headers and body fields, resolving `{{SECRET:name}}` placeholders server-side
 6. Adds an `X-Blaxel-Request-Id` header to every proxied request for tracing
 
-Common CLI tools and high-level clients — `curl`, `pip`, `npm`, `git`, Python `requests`, Python `httpx` — work transparently via the injected `HTTP_PROXY` / `HTTPS_PROXY` / `SSL_CERT_FILE` environment variables. Lower-level libraries such as direct `urllib3` may require explicit proxy auth and CA configuration.
+Most HTTP clients work transparently because they read the injected `HTTP_PROXY`, `HTTPS_PROXY`, and `SSL_CERT_FILE` environment variables — `curl`, `pip`, `npm`, `git`, Python `requests`, and Python `httpx` all work out of the box. Lower-level libraries that don't follow these conventions (for example, calling `urllib3` directly) need to be pointed at the proxy explicitly.
 
 <Note>
 Localhost (`127.0.0.1`), private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), `169.254.169.254`, `.local`, and `.internal` are always bypassed automatically.
@@ -141,7 +141,7 @@ When proxy is configured, the sandbox automatically has:
 | Variable | Purpose |
 |---|---|
 | `HTTP_PROXY` | Proxy URL for HTTP traffic |
-| `HTTPS_PROXY` | Proxy URL for HTTPS traffic. The value normally uses an `http://...` proxy URL; HTTPS destinations are tunneled with CONNECT. |
+| `HTTPS_PROXY` | Proxy URL for HTTPS traffic |
 | `NO_PROXY` | Comma-separated bypass list (always includes localhost, private ranges) |
 | `NODE_EXTRA_CA_CERTS` | Path to CA cert for Node.js TLS verification |
 | `SSL_CERT_FILE` | Path to CA cert for other TLS clients (`curl`, Python, etc.) |
@@ -159,7 +159,7 @@ When proxy is enabled, common CLI tools and high-level clients work transparentl
 | Python `requests` | HTTPS | Automatic via env vars |
 | Python `httpx` | HTTPS | Automatic via env vars |
 
-Python's stdlib `urllib.request` works fine with an **HTTP** proxy (`HTTP_PROXY=http://...`), which is the normal pattern; it does not support HTTPS proxies (TLS-to-proxy) without monkey-patching, and we do not recommend it for that use case. Use `urllib3.ProxyManager` if you need explicit control:
+Python's stdlib `urllib.request` is not recommended with the proxy. Prefer `requests` or `httpx`, or configure `urllib3.ProxyManager` directly if you need lower-level control:
 
 ```python
 import os
@@ -188,30 +188,25 @@ print(resp.status, resp.data.decode())
 - **Wildcard matching**: `*.example.com` matches `sub.example.com` and `a.b.example.com` but not `example.com` itself
 - **No cross-route leakage**: Headers/secrets from one routing rule are never applied to requests matching a different rule
 - **User headers preserved**: The proxy adds injected headers alongside any headers the sandbox code sends — it does not overwrite user-sent headers
-- **Body merge**: Injected body fields are merged into the outbound JSON payload. User-sent fields take precedence if there's a key collision
+- **Body merge**: Injected body fields are merged into JSON request bodies up to 1 MB. User-sent fields take precedence on key collisions. Requests over 1 MB, requests without a known `Content-Length` (e.g. chunked uploads), and streaming RPCs are forwarded unchanged — use header injection for credentials in those cases
 - **Tracing**: Every proxied request gets an `X-Blaxel-Request-Id` header for observability
 - **Local traffic**: Requests to `localhost` / `127.0.0.1` are never routed through the proxy
 
-### HTTP/2 and gRPC through CONNECT
+### HTTP/2 and gRPC
 
-The MITM proxy advertises `h2, http/1.1` to the client and to the upstream origin during the inner TLS handshake established after CONNECT. It speaks HTTP/2 upstream when both sides support it and falls back to HTTP/1.1 transparently when they do not. Negotiation happens per inner TLS handshake.
+The proxy supports HTTP/2 and gRPC. Clients that previously required HTTP/1.1 workarounds now work without any flags or downgrades:
 
-HTTP/2 support lives **inside** the CONNECT tunnel only. The client connects to the proxy with an HTTP proxy URL (`HTTP_PROXY=http://...` or `HTTPS_PROXY=http://...`), sends a cleartext CONNECT, and then negotiates h2 on the inner TLS session terminated by the MITM proxy. RFC 8441 / extended CONNECT is not supported: do not use `HTTPS_PROXY=https://...` to negotiate HTTP/2 to the proxy itself.
-
-gRPC unary, server-streaming, client-streaming, and bidirectional RPCs flow through the proxy. gRPC trailers such as `grpc-status` and `grpc-message` are preserved, and header injection is applied per stream rather than per connection.
-
-Identity headers such as `X-Blaxel-Sandbox-Id` and the resolved routing rules are bound at CONNECT time. All h2 streams multiplexed over the same CONNECT share that identity and rule set. Config changes mid-connection apply to new CONNECTs, not in-flight streams.
-
-Clients that previously needed HTTP/1.1 workarounds can now use HTTP/2 normally:
-
-- `gcsfuse` (the Go GCS client uses h2 by default; `--client-protocol=http1` is no longer required)
-- gRPC SDKs for Go, Python `grpcio`, and Node `@grpc/grpc-js`
-- Go `net/http` with `Transport.ForceAttemptHTTP2 = true` (the default since Go 1.6)
+- `gcsfuse` and other Google Cloud clients (no need for `--client-protocol=http1`)
+- gRPC SDKs in Go, Python (`grpcio`), and Node (`@grpc/grpc-js`)
 - `curl --http2`
+- Go `net/http` (HTTP/2 is the default)
 
-Body injection requires buffering the request body. Lower-level `bodyInjections` rules (shown as `body` in the sandbox SDK examples) are skipped when the request body is long-lived or cannot be buffered, such as gRPC streaming RPCs or chunked uploads. Header injection has no such limitation.
+All four gRPC RPC styles — unary, server-streaming, client-streaming, and bidirectional — flow through, and gRPC trailers (`grpc-status`, `grpc-message`) are preserved end-to-end.
 
-Browsers and Go h2 clients often coalesce many requests onto one TLS connection. Per-stream audit logging is unchanged, with one line per request, but operators should expect fewer and busier MITM connections in metrics dashboards.
+A few things to keep in mind:
+
+- **Header injection works on every request**, including streaming RPCs.
+- **Body injection is skipped on streaming requests** (gRPC streams, chunked uploads). Use header injection to attach credentials on streaming workloads — see the body injection limits in [Behavior details](#behavior-details).
 
 ## Full example: agent sandbox with proxy + firewall
 


### PR DESCRIPTION
Document Python client caveats and the current HTTP/2/gRPC behavior for MITM CONNECT tunnels.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Clarifies proxy HTTP client support by documenting which clients work out of the box (adding `httpx`, noting `urllib.request` limitations), adding a `urllib3.ProxyManager` manual configuration example, expanding body injection limits (1 MB cap, streaming behavior), and adding an HTTP/2 and gRPC compatibility section.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 75312c18158fc4f3556c3dda8fe4dd4c64780bb2.</sup>
<!-- /MENDRAL_SUMMARY -->