### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -561,10 +561,15 @@ components:
       required:
       - region
     EgressGatewayUsage:
+      type: object
       description: Sandboxes currently bound to each egress gateway. Returned by GET
         /egressgateways/usage so the egress-IPs UI can render attachment counts without
         fetching the sandboxes listing full. Keys are gateway names; values are sandbox
         names.
+      additionalProperties:
+        items:
+          type: string
+        type: array
     EgressIP:
       type: object
       description: An individual IP address allocated from an egress gateway for dedicated


### PR DESCRIPTION
Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds missing OpenAPI schema definition to `EgressGatewayUsage` component: `type: object` and `additionalProperties` typed as `array` of `string`, representing a `map[string][]string` structure where keys are gateway names and values are lists of sandbox names.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 83b81af9245a0dbd94a1aa4aaa7359073a6771e9.</sup>
<!-- /MENDRAL_SUMMARY -->