### PR TITLE
docs: add page for sandbox env vars

### DIFF
--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -482,7 +482,7 @@ You can explore the contents of a sandbox with an interactive terminal. You can 
     Interact with a sandbox through its MCP server.
   </Card>
   <Card title="Variables and secrets" icon="key" href="/Sandboxes/Variables-and-secrets">
-    Set environment variables in sandboxes.
+    Set environment variables and secrets in sandboxes.
   </Card>
   <Card title="Processes and commands" icon="terminal" href="/Sandboxes/Processes">
     Execute and manage processes in sandboxes.

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -481,6 +481,9 @@ You can explore the contents of a sandbox with an interactive terminal. You can 
   <Card title="MCP server" icon="robot" href="/Sandboxes/MCP">
     Interact with a sandbox through its MCP server.
   </Card>
+  <Card title="Variables and secrets" icon="key" href="/Sandboxes/Variables-and-secrets">
+    Set environment variables in sandboxes.
+  </Card>
   <Card title="Processes and commands" icon="terminal" href="/Sandboxes/Processes">
     Execute and manage processes in sandboxes.
   </Card>

--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -140,7 +140,7 @@ PYTHON_ENV = "development"
 ```
 
 <Note>
-  Currently, it is not possible to add or update environment variables for a sandbox after it is created. Ensure that any required environment variables are defined in your Dockerfile, your `blaxel.toml` file, or at sandbox creation time using the Blaxel SDKs.
+  It is not possible to add or update environment variables for a sandbox after it is created. Ensure that any required environment variables are defined in your Dockerfile, your `blaxel.toml` file, or at sandbox creation time using the Blaxel SDKs. See the [variables and secrets](/Sandboxes/Variables-and-secrets) documentation for details.
 </Note>
 
 ##### 4. Define initialization
@@ -231,7 +231,7 @@ The Blaxel SDK includes a declarative image builder that lets you define custom 
 This approach is ideal for dynamic image definitions, CI/CD pipelines, or when your image configuration depends on runtime logic.
 
 <Note>
-  The Declarative Image Builder is available in the **TypeScript** and **Python** SDKs. The Go SDK does not support this feature.
+  The declarative image builder is available in the **TypeScript** and **Python** SDKs. The Go SDK does not support this feature.
 </Note>
 
 Here is a simple example of how to use it:

--- a/Sandboxes/Variables-and-secrets.mdx
+++ b/Sandboxes/Variables-and-secrets.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Variables and secrets'
-description: 'Configure environment variables for Blaxel sandboxes to securely manage API keys, credentials, and runtime configuration values.'
+description: 'Configure environment variables and secrets for Blaxel sandboxes to securely manage API keys, credentials, and runtime configuration values.'
 ---
 
 ## Environment variables
@@ -12,8 +12,6 @@ There are multiple ways to configure environment variables in Blaxel sandboxes.
 </Note>
 
 ### When building new sandbox images
-
-#### Set variables in the sandbox image
 
 Environment variables defined in the sandbox image with the `ENV` Dockerfile directive are available in every sandbox created from it.
 

--- a/Sandboxes/Variables-and-secrets.mdx
+++ b/Sandboxes/Variables-and-secrets.mdx
@@ -1,0 +1,143 @@
+---
+title: 'Variables and secrets'
+description: 'Configure environment variables for Blaxel sandboxes to securely manage API keys, credentials, and runtime configuration values.'
+---
+
+There are multiple ways to configure environment variables in Blaxel sandboxes.
+
+<Note>
+  Environment variables cannot be added or changed after a sandbox is created. Set all required variables in your Dockerfile, `blaxel.toml`, or at sandbox creation time.
+</Note>
+
+## Set variables at sandbox creation time
+
+Pass `envs` as an array of name/value objects when creating a sandbox with the Blaxel SDKs. These are set as environment variables and are available to every process running inside the sandbox.
+
+<CodeGroup>
+
+```typescript TypeScript
+import { SandboxInstance } from "@blaxel/core";
+
+const sandbox = await SandboxInstance.createIfNotExists({
+  name: "my-sandbox",
+  image: "blaxel/base-image:latest",
+  region: "us-pdx-1",
+  envs: [
+    { name: "NODE_ENV", value: "production" },
+    { name: "PORT", value: "3000" },
+  ],
+});
+```
+
+```python Python
+from blaxel.core import SandboxInstance
+
+sandbox = await SandboxInstance.create_if_not_exists({
+  "name": "my-sandbox",
+  "image": "blaxel/base-image:latest",
+  "region": "us-pdx-1",
+  "envs": [
+    { "name": "NODE_ENV", "value": "production" },
+    { "name": "PORT", "value": "3000" },
+  ],
+})
+```
+
+</CodeGroup>
+
+
+## Set variables in the sandbox image
+
+Environment variables defined in the sandbox image with the `ENV` Dockerfile directive are available in every sandbox created from it.
+
+```dockerfile
+FROM blaxel/base-image:latest
+
+ENV NODE_ENV=production
+ENV PORT=3000
+```
+
+<Warning>
+  Never add secrets in a Dockerfile.
+</Warning>
+
+Environment variables can also be set when creating sandbox images with the [declarative image builder](/Sandboxes/Templates#Blaxel-SDK):
+
+<CodeGroup>
+
+```typescript TypeScript
+import { ImageInstance } from "@blaxel/core";
+
+const sandbox = await ImageInstance.fromRegistry("node:20-alpine")
+  .workdir("/app")
+  .env({
+    NODE_ENV: "production",
+    PORT: "3000",
+  })
+  .build({ name: "my-sandbox", memory: 4096 });
+```
+
+```python Python
+from blaxel.core import ImageInstance
+
+sandbox = await (
+    ImageInstance.from_registry("node:20-alpine")
+    .workdir("/app")
+    .env(NODE_ENV="production", PORT="3000")
+    .build(name="my-sandbox", memory=4096)
+)
+```
+
+</CodeGroup>
+
+## Set variables in the blaxel.toml file
+
+Environment variables can be defined in the `[env]` section of the `blaxel.toml` file:
+
+```toml
+name = "my-sandbox"
+type = "sandbox"
+
+[runtime]
+memory = 4096
+
+[env]
+NODE_ENV = "production"
+PORT = "3000"
+```
+
+## Set variables at process execution time
+
+Environment variables can also be set at process execution, applicable only to that specific process.
+
+<CodeGroup>
+
+```typescript TypeScript
+import { SandboxInstance } from "@blaxel/core";
+
+const sandbox = await SandboxInstance.get("my-sandbox");
+
+const process = await sandbox.process.exec({
+  command: "node server.js",
+  env: {
+    PORT: "8080",
+    LOG_LEVEL: "debug",
+  },
+});
+```
+
+```python Python
+from blaxel.core import SandboxInstance
+
+sandbox = await SandboxInstance.get("my-sandbox")
+
+process = await sandbox.process.exec({
+  "command": "node server.js",
+  "env": {
+    "PORT": "8080",
+    "LOG_LEVEL": "debug",
+  },
+})
+```
+
+</CodeGroup>

--- a/Sandboxes/Variables-and-secrets.mdx
+++ b/Sandboxes/Variables-and-secrets.mdx
@@ -92,7 +92,7 @@ sandbox = await (
 
 ## Set variables in the blaxel.toml file
 
-Environment variables can be defined in the `[env]` section of the `blaxel.toml` file:
+You can define enviroment variables for your sandbox in the `blaxel.toml` file at the root level of your project. These variables are NOT intended to be used as secrets, but as configuration variables.
 
 ```toml
 name = "my-sandbox"
@@ -141,3 +141,33 @@ process = await sandbox.process.exec({
 ```
 
 </CodeGroup>
+
+## Set secrets in a .env file
+
+Create a `.env` file at the root of your project to store secrets. Blaxel loads it from this default location when you deploy or run your code locally.
+
+Blaxel assumes that all variables in this file are secrets. The secrets will be encrypted when stored in Blaxel's database after deployment
+
+```bash .env
+MY_SECRET=123456
+```
+
+You can then read secrets in your application code:
+
+<CodeGroup>
+```typescript TypeScript
+import { env } from "@blaxel/core";
+
+console.info(env.MY_SECRET); // 123456
+```
+
+```python Python
+import os
+
+os.environ.get("MY_SECRET")
+```
+</CodeGroup>
+
+<Tip>
+  Add `.env` to your `.gitignore` to avoid committing sensitive values.
+</Tip>

--- a/Sandboxes/Variables-and-secrets.mdx
+++ b/Sandboxes/Variables-and-secrets.mdx
@@ -3,15 +3,67 @@ title: 'Variables and secrets'
 description: 'Configure environment variables for Blaxel sandboxes to securely manage API keys, credentials, and runtime configuration values.'
 ---
 
+## Environment variables
+
 There are multiple ways to configure environment variables in Blaxel sandboxes.
 
 <Note>
   Environment variables cannot be added or changed after a sandbox is created. Set all required variables in your Dockerfile, `blaxel.toml`, or at sandbox creation time.
 </Note>
 
-## Set variables at sandbox creation time
+### When building new sandbox images
 
-Pass `envs` as an array of name/value objects when creating a sandbox with the Blaxel SDKs. These are set as environment variables and are available to every process running inside the sandbox.
+#### Set variables in the sandbox image
+
+Environment variables defined in the sandbox image with the `ENV` Dockerfile directive are available in every sandbox created from it.
+
+```dockerfile
+FROM blaxel/base-image:latest
+
+ENV NODE_ENV=production
+ENV PORT=3000
+```
+
+<Warning>
+  Never add secrets in a Dockerfile.
+</Warning>
+
+This also applies when creating sandbox images with the [declarative image builder](/Sandboxes/Templates#Blaxel-SDK):
+
+<CodeGroup>
+
+```typescript TypeScript
+import { ImageInstance } from "@blaxel/core";
+
+const sandbox = await ImageInstance.fromRegistry("node:20-alpine")
+  .workdir("/app")
+  .env({
+    NODE_ENV: "production",
+    PORT: "3000",
+  })
+  .build({ name: "my-sandbox", memory: 4096 });
+```
+
+```python Python
+from blaxel.core import ImageInstance
+
+sandbox = await (
+    ImageInstance.from_registry("node:20-alpine")
+    .workdir("/app")
+    .env(NODE_ENV="production", PORT="3000")
+    .build(name="my-sandbox", memory=4096)
+)
+```
+
+</CodeGroup>
+
+### When instantiating sandboxes from existing images
+
+When instantiating sandboxes from existing images, any environment variables defined in the base image are automatically available. In addition to this, environment variables can be set using the following methods.
+
+#### Set variables at sandbox creation time
+
+Pass `envs` as an array of name/value objects when creating a sandbox with the Blaxel SDKs. These are set as environment variables and are available to every process running inside the deployed sandbox.
 
 <CodeGroup>
 
@@ -45,54 +97,13 @@ sandbox = await SandboxInstance.create_if_not_exists({
 
 </CodeGroup>
 
+#### Set variables in the blaxel.toml file
 
-## Set variables in the sandbox image
+You can define environment variables for your sandbox in the `blaxel.toml` file at the root level of your project. These variables are NOT intended to be used as secrets, but as configuration variables.
 
-Environment variables defined in the sandbox image with the `ENV` Dockerfile directive are available in every sandbox created from it.
-
-```dockerfile
-FROM blaxel/base-image:latest
-
-ENV NODE_ENV=production
-ENV PORT=3000
-```
-
-<Warning>
-  Never add secrets in a Dockerfile.
-</Warning>
-
-Environment variables can also be set when creating sandbox images with the [declarative image builder](/Sandboxes/Templates#Blaxel-SDK):
-
-<CodeGroup>
-
-```typescript TypeScript
-import { ImageInstance } from "@blaxel/core";
-
-const sandbox = await ImageInstance.fromRegistry("node:20-alpine")
-  .workdir("/app")
-  .env({
-    NODE_ENV: "production",
-    PORT: "3000",
-  })
-  .build({ name: "my-sandbox", memory: 4096 });
-```
-
-```python Python
-from blaxel.core import ImageInstance
-
-sandbox = await (
-    ImageInstance.from_registry("node:20-alpine")
-    .workdir("/app")
-    .env(NODE_ENV="production", PORT="3000")
-    .build(name="my-sandbox", memory=4096)
-)
-```
-
-</CodeGroup>
-
-## Set variables in the blaxel.toml file
-
-You can define enviroment variables for your sandbox in the `blaxel.toml` file at the root level of your project. These variables are NOT intended to be used as secrets, but as configuration variables.
+<Note>
+  Variables defined in `blaxel.toml` are applied at deployment time when you run `bl push` or `bl deploy`. They are not baked into the sandbox image. If you create a new sandbox from the same image using the SDKs, these variables will not be available.
+</Note>
 
 ```toml
 name = "my-sandbox"
@@ -106,7 +117,7 @@ NODE_ENV = "production"
 PORT = "3000"
 ```
 
-## Set variables at process execution time
+### When executing sandbox processes
 
 Environment variables can also be set at process execution, applicable only to that specific process.
 
@@ -142,11 +153,23 @@ process = await sandbox.process.exec({
 
 </CodeGroup>
 
-## Set secrets in a .env file
+## Secrets
 
-Create a `.env` file at the root of your project to store secrets. Blaxel loads it from this default location when you deploy or run your code locally.
+### Use proxy injection (recommended)
 
-Blaxel assumes that all variables in this file are secrets. The secrets will be encrypted when stored in Blaxel's database after deployment
+The recommended way to inject secrets into a sandbox is with the Blaxel proxy. This intercepts outbound HTTPS requests from the sandbox and injects secrets server-side using `{{SECRET:name}}` placeholders. The sandbox code never sees raw API keys or credentials.
+
+See the [proxy routing with secrets injection](/Sandboxes/Proxy-secrets-injection) documentation for examples.
+
+### Set secrets in a .env file
+
+To have secrets inside the sandbox, create a `.env` file at the root of your project to store secrets. Blaxel loads it from this default location when you deploy or run your code locally.
+
+<Note>
+  Secrets in `.env` are applied at deployment time when you run `bl push` or `bl deploy`. They are not baked into the image. If you create a new sandbox from the same image using the SDKs, these secrets will not be available.
+</Note>
+
+Blaxel assumes that all variables in this file are secrets. The secrets will be encrypted when stored in Blaxel's database after deployment.
 
 ```bash .env
 MY_SECRET=123456

--- a/Sandboxes/Variables-and-secrets.mdx
+++ b/Sandboxes/Variables-and-secrets.mdx
@@ -8,7 +8,7 @@ description: 'Configure environment variables and secrets for Blaxel sandboxes t
 There are multiple ways to configure environment variables in Blaxel sandboxes.
 
 <Note>
-  Environment variables cannot be added or changed after a sandbox is created. Set all required variables in your Dockerfile, `blaxel.toml`, or at sandbox creation time.
+  Environment variables cannot be added or changed after a sandbox is created. Set all required variables in your Dockerfile, or at sandbox creation time.
 </Note>
 
 ### When building new sandbox images
@@ -95,26 +95,6 @@ sandbox = await SandboxInstance.create_if_not_exists({
 
 </CodeGroup>
 
-#### Set variables in the blaxel.toml file
-
-You can define environment variables for your sandbox in the `blaxel.toml` file at the root level of your project. These variables are NOT intended to be used as secrets, but as configuration variables.
-
-<Note>
-  Variables defined in `blaxel.toml` are applied at deployment time when you run `bl push` or `bl deploy`. They are not baked into the sandbox image. If you create a new sandbox from the same image using the SDKs, these variables will not be available.
-</Note>
-
-```toml
-name = "my-sandbox"
-type = "sandbox"
-
-[runtime]
-memory = 4096
-
-[env]
-NODE_ENV = "production"
-PORT = "3000"
-```
-
 ### When executing sandbox processes
 
 Environment variables can also be set at process execution, applicable only to that specific process.
@@ -158,37 +138,3 @@ process = await sandbox.process.exec({
 The recommended way to inject secrets into a sandbox is with the Blaxel proxy. This intercepts outbound HTTPS requests from the sandbox and injects secrets server-side using `{{SECRET:name}}` placeholders. The sandbox code never sees raw API keys or credentials.
 
 See the [proxy routing with secrets injection](/Sandboxes/Proxy-secrets-injection) documentation for examples.
-
-### Set secrets in a .env file
-
-To have secrets inside the sandbox, create a `.env` file at the root of your project to store secrets. Blaxel loads it from this default location when you deploy or run your code locally.
-
-<Note>
-  Secrets in `.env` are applied at deployment time when you run `bl push` or `bl deploy`. They are not baked into the image. If you create a new sandbox from the same image using the SDKs, these secrets will not be available.
-</Note>
-
-Blaxel assumes that all variables in this file are secrets. The secrets will be encrypted when stored in Blaxel's database after deployment.
-
-```bash .env
-MY_SECRET=123456
-```
-
-You can then read secrets in your application code:
-
-<CodeGroup>
-```typescript TypeScript
-import { env } from "@blaxel/core";
-
-console.info(env.MY_SECRET); // 123456
-```
-
-```python Python
-import os
-
-os.environ.get("MY_SECRET")
-```
-</CodeGroup>
-
-<Tip>
-  Add `.env` to your `.gitignore` to avoid committing sensitive values.
-</Tip>

--- a/docs.json
+++ b/docs.json
@@ -46,6 +46,7 @@
               "Sandboxes/MCP",
               "Sandboxes/Codegen-tools",
               "Sandboxes/Log-streaming",
+              "Sandboxes/Variables-and-secrets",
               {
                 "group": "Ports, previews & sessions",
                 "pages": [
@@ -543,6 +544,10 @@
     {
       "source": "/sandboxes/processes",
       "destination": "/Sandboxes/Processes"
+    },
+    {
+      "source": "/sandboxes/variables-and-secrets",
+      "destination": "/Sandboxes/Variables-and-secrets"
     },
     {
       "source": "/sandboxes/proxy",


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new `Sandboxes/Variables-and-secrets.mdx` page documenting environment variable configuration (Dockerfile, declarative builder, SDK creation-time, process-level) and secrets injection via the Blaxel proxy. Updates Overview card links, Templates notes, and docs.json navigation/redirects.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit dc5f31110f1e6224ed8877e3ed26ac5bb909b069.</sup>
<!-- /MENDRAL_SUMMARY -->