### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -396,6 +396,11 @@ components:
         cnameRecords:
           type: string
           description: CNAME target for the domain
+        fallbackPreviewId:
+          type: string
+          description: Preview ID to route to when a preview lookup fails on this
+            custom domain
+          example: my-fallback-preview
         lastVerifiedAt:
           type: string
           description: Last verification attempt timestamp
@@ -6748,6 +6753,14 @@ paths:
     post:
       description: Create a preview
       operationId: CreateSandboxPreview
+      parameters:
+      - description: Force creation by deleting conflicting previews that use the
+          same custom domain prefix URL
+        in: query
+        name: force
+        required: false
+        schema:
+          type: boolean
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Automated update of api docs

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `fallbackPreviewId` field to the custom domain schema and a `force` query parameter to the `CreateSandboxPreview` endpoint in the OpenAPI spec.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 798733e456a36d60777e5c8bb205f6aa5ec749a5.</sup>
<!-- /MENDRAL_SUMMARY -->