### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -2952,8 +2952,8 @@ components:
         extraArgs:
           type: object
           description: 'Extra arguments for sandbox kernel selection. Supported keys:
-            ''iptables'', ''nvme''. Values: ''enabled'' or ''disabled''. Determines
-            which kernel variant the sandbox runs on. Immutable after creation.'
+            ''iptables'', ''nvme'', ''nfs''. Values: ''enabled'' or ''disabled''.
+            Determines which kernel variant the sandbox runs on. Immutable after creation.'
           additionalProperties:
             type: string
         image:


### PR DESCRIPTION
Fixes ENG-3148

Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Automated API docs update adding `'nfs'` to the list of supported `extraArgs` keys for sandbox kernel selection.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a3ffa02a8bf8a8f721a3a9d3d3d1682c7fd68622.</sup>
<!-- /MENDRAL_SUMMARY -->