### PR TITLE
chore: auto-update cli docs from upstream

### DIFF
--- a/cli-reference/commands/bl_drive_list.md
+++ b/cli-reference/commands/bl_drive_list.md
@@ -22,12 +22,21 @@ bl drive list [flags]
 
   # List drives in JSON format
   bl drive list -o json
+
+  # Fetch the next page
+  bl drive list --cursor <cursor>
+
+  # Fetch every drive
+  bl drive list --all
 ```
 
 ### Options
 
 ```
-  -h, --help   help for list
+      --all             Fetch all pages (may be slow for large collections)
+      --cursor string   Cursor from a previous page to fetch the next page of results
+  -h, --help            help for list
+      --limit int       Maximum number of items to return (auto-paginates when above 200) (default 200)
 ```
 
 ### Options inherited from parent commands

--- a/cli-reference/commands/bl_get_agents.md
+++ b/cli-reference/commands/bl_get_agents.md
@@ -13,7 +13,10 @@ bl get agents [flags]
 ### Options
 
 ```
-  -h, --help   help for agents
+      --all             Fetch all pages (may be slow for large collections)
+      --cursor string   Cursor from a previous page to fetch the next page of results
+  -h, --help            help for agents
+      --limit int       Maximum number of items to return (auto-paginates when above 200) (default 200)
 ```
 
 ### Options inherited from parent commands

--- a/cli-reference/commands/bl_get_drives.md
+++ b/cli-reference/commands/bl_get_drives.md
@@ -13,7 +13,10 @@ bl get drives [flags]
 ### Options
 
 ```
-  -h, --help   help for drives
+      --all             Fetch all pages (may be slow for large collections)
+      --cursor string   Cursor from a previous page to fetch the next page of results
+  -h, --help            help for drives
+      --limit int       Maximum number of items to return (auto-paginates when above 200) (default 200)
 ```
 
 ### Options inherited from parent commands

--- a/cli-reference/commands/bl_get_functions.md
+++ b/cli-reference/commands/bl_get_functions.md
@@ -13,7 +13,10 @@ bl get functions [flags]
 ### Options
 
 ```
-  -h, --help   help for functions
+      --all             Fetch all pages (may be slow for large collections)
+      --cursor string   Cursor from a previous page to fetch the next page of results
+  -h, --help            help for functions
+      --limit int       Maximum number of items to return (auto-paginates when above 200) (default 200)
 ```
 
 ### Options inherited from parent commands

--- a/cli-reference/commands/bl_get_jobs.md
+++ b/cli-reference/commands/bl_get_jobs.md
@@ -13,7 +13,10 @@ bl get jobs [flags]
 ### Options
 
 ```
-  -h, --help   help for jobs
+      --all             Fetch all pages (may be slow for large collections)
+      --cursor string   Cursor from a previous page to fetch the next page of results
+  -h, --help            help for jobs
+      --limit int       Maximum number of items to return (auto-paginates when above 200) (default 200)
 ```
 
 ### Options inherited from parent commands

--- a/cli-reference/commands/bl_get_models.md
+++ b/cli-reference/commands/bl_get_models.md
@@ -13,7 +13,10 @@ bl get models [flags]
 ### Options
 
 ```
-  -h, --help   help for models
+      --all             Fetch all pages (may be slow for large collections)
+      --cursor string   Cursor from a previous page to fetch the next page of results
+  -h, --help            help for models
+      --limit int       Maximum number of items to return (auto-paginates when above 200) (default 200)
 ```
 
 ### Options inherited from parent commands

--- a/cli-reference/commands/bl_get_policies.md
+++ b/cli-reference/commands/bl_get_policies.md
@@ -13,7 +13,10 @@ bl get policies [flags]
 ### Options
 
 ```
-  -h, --help   help for policies
+      --all             Fetch all pages (may be slow for large collections)
+      --cursor string   Cursor from a previous page to fetch the next page of results
+  -h, --help            help for policies
+      --limit int       Maximum number of items to return (auto-paginates when above 200) (default 200)
 ```
 
 ### Options inherited from parent commands

--- a/cli-reference/commands/bl_get_sandboxes.md
+++ b/cli-reference/commands/bl_get_sandboxes.md
@@ -13,7 +13,10 @@ bl get sandboxes [flags]
 ### Options
 
 ```
-  -h, --help   help for sandboxes
+      --all             Fetch all pages (may be slow for large collections)
+      --cursor string   Cursor from a previous page to fetch the next page of results
+  -h, --help            help for sandboxes
+      --limit int       Maximum number of items to return (auto-paginates when above 200) (default 200)
 ```
 
 ### Options inherited from parent commands

--- a/cli-reference/commands/bl_get_volumes.md
+++ b/cli-reference/commands/bl_get_volumes.md
@@ -13,7 +13,10 @@ bl get volumes [flags]
 ### Options
 
 ```
-  -h, --help   help for volumes
+      --all             Fetch all pages (may be slow for large collections)
+      --cursor string   Cursor from a previous page to fetch the next page of results
+  -h, --help            help for volumes
+      --limit int       Maximum number of items to return (auto-paginates when above 200) (default 200)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Automated update of CLI docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Automated update adding pagination options (`--all`, `--cursor`, `--limit`) to CLI reference docs for list/get commands across agents, drives, functions, jobs, models, policies, sandboxes, and volumes.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3fe66d70b2d7e5a555915ad011d5b75eda3ca1b5.</sup>
<!-- /MENDRAL_SUMMARY -->