### PR TITLE
feat: add codex tutorial

### DIFF
--- a/Tutorials/Codex.mdx
+++ b/Tutorials/Codex.mdx
@@ -270,7 +270,7 @@ Codex will connect to the application sandbox, inspect the Next.js codebase and 
 Want more information on building and deploying with OpenAI on Blaxel? Check out the following resources:
 
 <CardGroup>
-  <Card title="Use with Blaxel sandboxes" icon="thumbs-up" href="/Tutorials/OpenAI-Agents-SDK">
+  <Card title="Use OpenAI Agents SDK with Blaxel sandboxes" icon="thumbs-up" href="/Tutorials/OpenAI-Agents-SDK">
     Build compute-capable agents backed by Blaxel sandboxes using OpenAI Agents SDK.
   </Card>
 

--- a/Tutorials/Codex.mdx
+++ b/Tutorials/Codex.mdx
@@ -124,7 +124,8 @@ Before starting, ensure you have:
         memory: 4096,
         region: "us-pdx-1",
         envs: [
-          { name: "OPENAI_API_KEY", value: openaiApiKey }
+          { name: "OPENAI_API_KEY", value: openaiApiKey },
+          { name: "BLAXEL_API_KEY", value: blaxelApiKey }
         ]
       });
       console.log("Codex sandbox created");
@@ -195,7 +196,8 @@ Before starting, ensure you have:
             "memory": 4096,
             "region": "us-pdx-1",
             "envs": [
-                {"name": "OPENAI_API_KEY", "value": openai_api_key}
+                {"name": "OPENAI_API_KEY", "value": openai_api_key},
+                {"name": "BLAXEL_API_KEY", "value": blaxel_api_key}
             ]
         })
         print("Codex sandbox created")
@@ -210,7 +212,7 @@ Before starting, ensure you have:
       - `nextjs-sandbox` using Blaxel's Next.js base image
 
     In the Codex sandbox, it:
-    - adds the OpenAI API key to `codex-sandbox` as an environment variable named `OPENAI_API_KEY`.
+    - adds the Blaxel and OpenAI API keys to `codex-sandbox` as environment variables.
 
     In the application sandbox, it:
     - starts the Next.js dev server in `nextjs-sandbox` on port 3000;
@@ -240,13 +242,13 @@ Before starting, ensure you have:
     bl connect sandbox codex-sandbox
     ```
 
-1. Start Codex, passing the application sandbox's MCP server URL (obtained from the sandbox creation script in the previous section) and your Blaxel API key:
+1. Configure Codex to connect to the application sandbox's MCP server URL (obtained from the sandbox creation script in the previous section) with your Blaxel API key (set in the sandbox environment):
 
     ```shell
-    codex --mcp-server '{"type":"http","url":"YOUR-SANDBOX-MCP-URL-HERE","headers":{"Authorization":"Bearer YOUR-BLAXEL-API-KEY-HERE"}}'
+    codex mcp add sandbox --url YOUR-SANDBOX-MCP-URL-HERE  --bearer-token-env-var  BLAXEL_API_KEY
     ```
 
-Codex will connect to the application sandbox's MCP server and prompt you for a task.
+1. Start Codex and confirm that it is connected to the sandbox MCP server with the `/mcp` command. This command should return the list of tools available in the sandbox.
 
 ## Test Codex
 
@@ -268,23 +270,11 @@ Codex will connect to the application sandbox, inspect the Next.js codebase and 
 Want more information on building and deploying with OpenAI on Blaxel? Check out the following resources:
 
 <CardGroup>
-  <Card title="OpenAI Agents SDK" icon="star-christmas" href="/Tutorials/OpenAI-Agents-SDK">
-    Build and deploy OpenAI Agents SDK agents on Blaxel.
+  <Card title="Use with Blaxel sandboxes" icon="thumbs-up" href="/Tutorials/OpenAI-Agents-SDK">
+    Build compute-capable agents backed by Blaxel sandboxes using OpenAI Agents SDK.
   </Card>
 
-  <Card title="Claude Agent SDK" icon="star-christmas" href="/Tutorials/Claude-Agent-SDK">
-    Build and deploy Claude Agent SDK agents on Blaxel.
-  </Card>
-
-  <Card title="Connect to a Blaxel sandbox from Claude Agent SDK" icon="thumbs-up" href="/Tutorials/Claude-Agent-SDK-MCP">
-    An agent that operates a sandbox using the sandbox's MCP server and Claude Agent SDK.
-  </Card>
-
-  <Card title="Self-host Claude Managed Agents on Blaxel" icon="server" href="/Tutorials/Claude-Managed-Agents">
-    Deploy a self-hosted Claude Managed Agents environment on Blaxel.
-  </Card>
-
-  <Card title="Deploy your agent code to Blaxel" icon="server" href="../Agents/Deploy-an-agent">
-    Complete tutorial for deploying AI agents on Blaxel.
+  <Card title="Deploy on Blaxel" icon="star-christmas" href="/Tutorials/OpenAI-Agents-SDK-Deployment">
+    Build and deploy agents with OpenAI Agents SDK to Blaxel.
   </Card>
 </CardGroup>

--- a/Tutorials/Codex.mdx
+++ b/Tutorials/Codex.mdx
@@ -1,0 +1,290 @@
+---
+title: 'Run Codex in a sandbox'
+description: 'Run OpenAI Codex inside a Blaxel sandbox to execute coding tasks on a hosted codebase, with persistent storage and secure network access.'
+---
+
+This tutorial explains how to run [OpenAI Codex](https://openai.com/codex) inside a Blaxel sandbox and have it execute coding tasks on a codebase hosted in a different sandbox.
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- a Python or TypeScript development environment;
+- a Blaxel account and API key. If not, [sign up for a Blaxel account](https://blaxel.ai) and [create a Blaxel API key](../Security/Access-tokens#api-keys);
+- an OpenAI API key with access to Codex. If not, [create an OpenAI API key](https://platform.openai.com/api-keys);
+
+## Install the Blaxel CLI and SDK
+
+1. [Download and install the Blaxel CLI](https://docs.blaxel.ai/cli-reference/introduction#install) and log in to your Blaxel account:
+
+    ```shell
+    bl login
+    ```
+
+1. In a new directory, install the Blaxel SDK ([Python](https://github.com/blaxel-ai/sdk-python) and [TypeScript](https://github.com/blaxel-ai/sdk-typescript) are both supported):
+
+    <CodeGroup>
+    ```shell TypeScript (npm)
+    npm init # if new project
+    npm install @blaxel/core
+    ```
+
+
+    ```shell TypeScript (pnpm)
+    pnpm init # if new project
+    pnpm install @blaxel/core
+    ```
+
+
+    ```shell TypeScript (yarn)
+    yarn init # if new project
+    yarn add @blaxel/core
+    ```
+
+
+    ```shell TypeScript (bun)
+    bun init -m --yes # if new project
+    bun install @blaxel/core
+    ```
+
+    ```shell Python
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install blaxel
+    ```
+
+    </CodeGroup>
+
+## Create sandboxes
+
+1. In the host environment, define the following variables:
+
+    ```shell
+    export BLAXEL_API_KEY=YOUR-BLAXEL-API-KEY-HERE
+    export OPENAI_API_KEY=YOUR-OPENAI-API-KEY-HERE
+    ```
+
+1. Create a script named `main.py` (Python) or `index.ts` (TypeScript) in the same directory.
+
+    <CodeGroup>
+
+    ```typescript TypeScript
+    import { SandboxInstance } from "@blaxel/core";
+
+    async function main() {
+      // Check for required variables
+      const blaxelApiKey = process.env.BLAXEL_API_KEY;
+      if (!blaxelApiKey) {
+        throw new Error("BLAXEL_API_KEY environment variable is not set");
+      }
+      const openaiApiKey = process.env.OPENAI_API_KEY;
+      if (!openaiApiKey) {
+        throw new Error("OPENAI_API_KEY environment variable is not set");
+      }
+
+      // Create application sandbox
+      const appSandbox = await SandboxInstance.createIfNotExists({
+        name: "nextjs-sandbox",
+        image: "blaxel/nextjs:latest",
+        memory: 4096,
+        region: "us-pdx-1",
+      });
+      console.log("Application sandbox created");
+
+      // Start dev server in application sandbox
+      await appSandbox.process.exec({
+        workingDir: "/blaxel/app",
+        command: "npm run dev -- --hostname 0.0.0.0 --port 3000"
+      });
+      console.log("Application server started");
+
+      // Create preview URL
+      const appPreview = await appSandbox.previews.createIfNotExists({
+        metadata: { name: "app-preview" },
+        spec: {
+          port: 3000,
+          public: false,
+        }
+      });
+      console.log("Preview URL created");
+
+      // Create preview token
+      // Valid for 24 hours
+      const expiresAt = new Date(Date.now() + 1440 * 60 * 1000);
+      const token = await appPreview.tokens.create(expiresAt);
+
+      // Get preview URL
+      console.log(`Preview URL: ${appPreview.spec.url}?bl_preview_token=${token.value}`);
+      console.log(`MCP URL: ${appSandbox.metadata.url}/mcp`);
+
+      // Create Codex sandbox
+      const codexSandbox = await SandboxInstance.createIfNotExists({
+        name: "codex-sandbox",
+        image: "blaxel/codex:latest",
+        memory: 4096,
+        region: "us-pdx-1",
+        envs: [
+          { name: "OPENAI_API_KEY", value: openaiApiKey }
+        ]
+      });
+      console.log("Codex sandbox created");
+    }
+
+    main();
+
+    ```
+
+    ```python Python
+    import asyncio
+    import os
+    import sys
+    from datetime import datetime, timedelta, UTC
+
+    from blaxel.core import SandboxInstance
+
+    async def main():
+
+        # Check for required variables
+        blaxel_api_key = os.getenv("BLAXEL_API_KEY")
+        if not blaxel_api_key:
+            raise ValueError("BLAXEL_API_KEY environment variable is not set")
+
+        openai_api_key = os.getenv("OPENAI_API_KEY")
+        if not openai_api_key:
+            raise ValueError("OPENAI_API_KEY environment variable is not set")
+
+        # Create application sandbox
+        app_sandbox = await SandboxInstance.create_if_not_exists({
+            "name": "nextjs-sandbox",
+            "image": "blaxel/nextjs:latest",
+            "memory": 4096,
+            "region": "us-pdx-1",
+        })
+        print("Application sandbox created")
+
+        # Start dev server in application sandbox
+        await app_sandbox.process.exec({
+          "working_dir": "/blaxel/app",
+          "command": "npm run dev -- --hostname 0.0.0.0 --port 3000"
+        })
+        print("Application server started")
+
+        # Create preview URL
+        app_preview = await app_sandbox.previews.create_if_not_exists({
+            "metadata": {"name": "app-preview"},
+            "spec": {
+                "port": 3000,
+                "public": False,
+            }
+        })
+        print("Preview URL created")
+
+        # Create preview token
+        # Valid for 24 hours
+        expires_at = datetime.now(UTC) + timedelta(minutes=1440)
+        token = await app_preview.tokens.create(expires_at)
+
+        # Get preview URL
+        print(f"Preview URL: {app_preview.spec.url}?bl_preview_token={token.value}")
+        print(f"MCP URL: {app_sandbox.metadata.url}/mcp")
+
+        # Create Codex sandbox
+        codex_sandbox = await SandboxInstance.create_if_not_exists({
+            "name": "codex-sandbox",
+            "image": "blaxel/codex:latest",
+            "memory": 4096,
+            "region": "us-pdx-1",
+            "envs": [
+                {"name": "OPENAI_API_KEY", "value": openai_api_key}
+            ]
+        })
+        print("Codex sandbox created")
+
+    if __name__ == "__main__":
+        asyncio.run(main())
+    ```
+    </CodeGroup>
+
+    This script creates two Blaxel sandboxes:
+      - `codex-sandbox` using Blaxel's pre-built Codex image, which includes the Codex CLI
+      - `nextjs-sandbox` using Blaxel's Next.js base image
+
+    In the Codex sandbox, it:
+    - adds the OpenAI API key to `codex-sandbox` as an environment variable named `OPENAI_API_KEY`.
+
+    In the application sandbox, it:
+    - starts the Next.js dev server in `nextjs-sandbox` on port 3000;
+    - creates a preview URL for the Next.js service running in `nextjs-sandbox` on port 3000;
+    - creates an access token for the preview URL, valid for 24 hours;
+    - returns the preview URL.
+
+1. Run the script to create the sandboxes and preview URL:
+
+    <CodeGroup>
+    ```python Python
+    python main.py
+    ```
+
+    ```typescript TypeScript
+    bun index.ts
+    ```
+    </CodeGroup>
+
+    Once complete, the script displays the generated preview URL for the Next.js application (for example, `https://b186....preview.bl.run?bl_preview_token=cbba622560db78e...`) and the MCP server URL (for example, `https://sbx-nextjs-sandbox....bl.run/mcp`) for the Next.js sandbox. Note these values, as you will require them in subsequent steps.
+
+## Configure and test Codex
+
+1. Connect to the Codex sandbox terminal:
+
+    ```shell
+    bl connect sandbox codex-sandbox
+    ```
+
+1. Start Codex, passing the application sandbox's MCP server URL (obtained from the sandbox creation script in the previous section) and your Blaxel API key:
+
+    ```shell
+    codex --mcp-server '{"type":"http","url":"YOUR-SANDBOX-MCP-URL-HERE","headers":{"Authorization":"Bearer YOUR-BLAXEL-API-KEY-HERE"}}'
+    ```
+
+Codex will connect to the application sandbox's MCP server and prompt you for a task.
+
+## Test Codex
+
+Once Codex starts, give it a coding task referencing the application sandbox, as in the example prompt below:
+
+```shell
+You have access to a sandbox environment over MCP. The sandbox includes tools to read and write files and directories and run commands. The sandbox includes a skeleton Next.js application at /blaxel/app. Update the application codebase and complete the coding task below.
+
+You must make all your changes only in the sandbox.
+Do not make any changes in the local environment.
+
+Your task is: create a website for a new board game of your own invention, including an interactive demo
+```
+
+Codex will connect to the application sandbox, inspect the Next.js codebase and make changes as per your request. Once complete, visit the application sandbox's preview URL (obtained from the sandbox creation script in the previous section) to see the result.
+
+## Resources
+
+Want more information on building and deploying with OpenAI on Blaxel? Check out the following resources:
+
+<CardGroup>
+  <Card title="OpenAI Agents SDK" icon="star-christmas" href="/Tutorials/OpenAI-Agents-SDK">
+    Build and deploy OpenAI Agents SDK agents on Blaxel.
+  </Card>
+
+  <Card title="Claude Agent SDK" icon="star-christmas" href="/Tutorials/Claude-Agent-SDK">
+    Build and deploy Claude Agent SDK agents on Blaxel.
+  </Card>
+
+  <Card title="Connect to a Blaxel sandbox from Claude Agent SDK" icon="thumbs-up" href="/Tutorials/Claude-Agent-SDK-MCP">
+    An agent that operates a sandbox using the sandbox's MCP server and Claude Agent SDK.
+  </Card>
+
+  <Card title="Self-host Claude Managed Agents on Blaxel" icon="server" href="/Tutorials/Claude-Managed-Agents">
+    Deploy a self-hosted Claude Managed Agents environment on Blaxel.
+  </Card>
+
+  <Card title="Deploy your agent code to Blaxel" icon="server" href="../Agents/Deploy-an-agent">
+    Complete tutorial for deploying AI agents on Blaxel.
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -262,11 +262,11 @@
                 ]
               },
               {
-                "group": "OpenAI Agents",
+                "group": "OpenAI / Codex",
                 "pages": [
+                  "Tutorials/Codex",
                   "Tutorials/OpenAI-Agents-SDK-Index",
-                  "Tutorials/OpenAI-Agents-SDK-Deployment",
-                  "Tutorials/Codex"
+                  "Tutorials/OpenAI-Agents-SDK-Deployment"
                 ]
               }
             ]

--- a/docs.json
+++ b/docs.json
@@ -265,7 +265,8 @@
                 "group": "OpenAI Agents",
                 "pages": [
                   "Tutorials/OpenAI-Agents-SDK-Index",
-                  "Tutorials/OpenAI-Agents-SDK-Deployment"
+                  "Tutorials/OpenAI-Agents-SDK-Deployment",
+                  "Tutorials/Codex"
                 ]
               }
             ]

--- a/docs.json
+++ b/docs.json
@@ -265,7 +265,6 @@
                 "group": "OpenAI / Codex",
                 "pages": [
                   "Tutorials/Codex",
-                  "Tutorials/OpenAI-Agents-SDK-Index",
                   "Tutorials/OpenAI-Agents-SDK-Deployment"
                 ]
               }


### PR DESCRIPTION
Fixes ENG-3212

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Second commit updates the Codex tutorial: passes `BLAXEL_API_KEY` as a sandbox env var, switches from inline `--mcp-server` JSON (which exposed the key in shell history) to `codex mcp add ... --bearer-token-env-var`, reorders pages in `docs.json`, and trims the Resources cards to OpenAI-only links.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 47a81c3463e1c470debefa8557503ca0c7fda540.</sup>
<!-- /MENDRAL_SUMMARY -->