### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -6846,7 +6846,7 @@ paths:
       description: Create a preview
       operationId: CreateSandboxPreview
       parameters:
-      - description: Force creation by deleting conflicting previews that use the
+      - description: Force creation by replacing conflicting previews that use the
           same custom domain prefix URL
         in: query
         name: force


### PR DESCRIPTION
Fixes ENG-3246

Automated update of api docs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Updates the API docs for the `CreateSandboxPreview` endpoint, changing the description of the `force` query parameter from "deleting conflicting previews" to "replacing conflicting previews".
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ffd37a7b76bd944845995df76967c001746a306b.</sup>
<!-- /MENDRAL_SUMMARY -->