### PR TITLE
docs: add note on build secrets for sandboxes

### DIFF
--- a/Sandboxes/Variables-and-secrets.mdx
+++ b/Sandboxes/Variables-and-secrets.mdx
@@ -57,11 +57,11 @@ sandbox = await (
 
 ### When instantiating sandboxes from existing images
 
-When instantiating sandboxes from existing images, any environment variables defined in the base image are automatically available. In addition to this, environment variables can be set using the following methods.
+When instantiating sandboxes from existing images, any environment variables defined in the base image are automatically available. Additional environment variables can be set using the following methods.
 
 #### Set variables at sandbox creation time
 
-Pass `envs` as an array of name/value objects when creating a sandbox with the Blaxel SDKs. These are set as environment variables and are available to every process running inside the deployed sandbox.
+Pass `envs` as an array of name/value objects when creating a sandbox with the Blaxel SDKs. These are set as environment variables and are available to every process running inside the deployed sandbox by default (although they can be overridden by process-level variables, discussed in the next section).
 
 <CodeGroup>
 
@@ -138,3 +138,21 @@ process = await sandbox.process.exec({
 The recommended way to inject secrets into a sandbox is with the Blaxel proxy. This intercepts outbound HTTPS requests from the sandbox and injects secrets server-side using `{{SECRET:name}}` placeholders. The sandbox code never sees raw API keys or credentials.
 
 See the [proxy routing with secrets injection](/Sandboxes/Proxy-secrets-injection) documentation for examples.
+
+### Use a .env.build file
+
+Build variables let you pass secrets and configuration values into the Docker build phase without exposing them at runtime. This is useful when your build process needs credentials that should never appear inside the deployed sandbox.
+
+Create a `.env.build` file in the root of your project for build secrets. A common example of this is installing private npm packages, which require an `NPM_TOKEN` during `npm install`. Variables defined here are injected during the build phase only and are never persisted in the runtime environment.
+
+```bash .env.build
+MY_SECRET_BUILD_VAR=I_AM_A_SECRET
+```
+
+<Tip>
+  Use the `--build-env-file` argument to `bl deploy` to specify a custom file name or path instead of the default `.env.build`.
+</Tip>
+
+<Warning>
+  Ensure that `.env.build` is ignored during commits to avoid accidentally making secrets public.
+</Warning>


### PR DESCRIPTION
Fixes ENG-3255

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds documentation about using `.env.build` files for passing build-time secrets to sandbox Docker builds, plus minor wording improvements to existing sections.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 34ec3be78e7a5883f183ff916df21f71ba0090cd.</sup>
<!-- /MENDRAL_SUMMARY -->