### PR TITLE
docs: add pagination examples

### DIFF
--- a/Agent-drive/Overview.mdx
+++ b/Agent-drive/Overview.mdx
@@ -242,6 +242,53 @@ bl drive mounts --sandbox my-sandbox
 
 ## List all drives
 
+To retrieve all drives in your workspace, use the Management API list endpoint with pagination.
+
+<Note>
+  Pagination is recommended for list operations because retrieving all available resources in a single request is slow and resource-intensive, and therefore does not scale well.
+</Note>
+
+Request the first page:
+
+```bash
+curl 'https://api.blaxel.ai/v0/drives?limit=50' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+The response includes a `data` array and a `meta` object:
+
+```json
+{
+  "data": [ ... ],
+  "meta": {
+    "hasMore": true,
+    "nextCursor": "...",
+    "total": 24
+  }
+}
+```
+
+Pass `meta.nextCursor` as `cursor` on the next request and repeat until `meta.hasMore` is `false`:
+
+```bash
+curl 'https://api.blaxel.ai/v0/drives?limit=50&cursor=NEXT_CURSOR' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+<Tip>
+  For accounts with multiple workspaces, specify the workspace as an additional request parameter, such as `?workspace=WORKSPACE_NAME&...`, or via an additional `X-Blaxel-Workspace: WORKSPACE_NAME` header in the request.
+</Tip>
+
+For more information, refer to the [API reference documentation](/api-reference/introduction#pagination).
+
+It is also possible to list all drives in a workspace using the SDKs.
+
+<Note>
+  This approach does not currently support pagination and is therefore not recommended when working with large lists.
+</Note>
+
 <CodeGroup>
 
 ```tsx TypeScript

--- a/Agents/Develop-an-agent-py.mdx
+++ b/Agents/Develop-an-agent-py.mdx
@@ -369,6 +369,10 @@ curl 'https://api.blaxel.ai/v0/agents?limit=50&cursor=NEXT_CURSOR' \
   -H 'Blaxel-Version: 2026-04-28'
 ```
 
+<Tip>
+  For accounts with multiple workspaces, specify the workspace as an additional request parameter, such as `?workspace=WORKSPACE_NAME&...`, or via an additional `X-Blaxel-Workspace: WORKSPACE_NAME` header in the request.
+</Tip>
+
 For more information, refer to the [API reference documentation](/api-reference/introduction#pagination).
 
 ## Customize the agent deployment

--- a/Agents/Develop-an-agent-py.mdx
+++ b/Agents/Develop-an-agent-py.mdx
@@ -332,6 +332,45 @@ first_agent_response = await bl_agent("first_agent").run(input);
 second_agent_response = await bl_agent("second_agent").run(first_agent_response);
 ```
 
+## List agents
+
+To retrieve all agents in your workspace, use the Management API list endpoint with pagination.
+
+<Note>
+  Pagination is recommended for list operations because retrieving all available resources in a single request is slow and resource-intensive, and therefore does not scale well.
+</Note>
+
+Request the first page:
+
+```bash
+curl 'https://api.blaxel.ai/v0/agents?limit=50' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+The response includes a `data` array and a `meta` object:
+
+```json
+{
+  "data": [ ... ],
+  "meta": {
+    "hasMore": true,
+    "nextCursor": "...",
+    "total": 312
+  }
+}
+```
+
+Pass `meta.nextCursor` as `cursor` on the next request and repeat until `meta.hasMore` is `false`:
+
+```bash
+curl 'https://api.blaxel.ai/v0/agents?limit=50&cursor=NEXT_CURSOR' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+For more information, refer to the [API reference documentation](/api-reference/introduction#pagination).
+
 ## Customize the agent deployment
 
 You can set custom parameters for an agent deployment (e.g. specify the agent name, etc.) in the [`blaxel.toml` file](/deployment-reference) at the root of your directory.

--- a/Agents/Develop-an-agent-ts.mdx
+++ b/Agents/Develop-an-agent-ts.mdx
@@ -325,6 +325,10 @@ curl 'https://api.blaxel.ai/v0/agents?limit=50&cursor=NEXT_CURSOR' \
   -H 'Blaxel-Version: 2026-04-28'
 ```
 
+<Tip>
+  For accounts with multiple workspaces, specify the workspace as an additional request parameter, such as `?workspace=WORKSPACE_NAME&...`, or via an additional `X-Blaxel-Workspace: WORKSPACE_NAME` header in the request.
+</Tip>
+
 For more information, refer to the [API reference documentation](/api-reference/introduction#pagination).
 
 ## Customize the agent deployment

--- a/Agents/Develop-an-agent-ts.mdx
+++ b/Agents/Develop-an-agent-ts.mdx
@@ -287,6 +287,46 @@ const myFirstAgentResponse = await blAgent("firstAgent").run(input);
 const mySecondAgentResponse = await blAgent("secondAgent").run(myFirstAgentResponse);
 ```
 
+
+## List agents
+
+To retrieve all agents in your workspace, use the Management API list endpoint with pagination.
+
+<Note>
+  Pagination is recommended for list operations because retrieving all available resources in a single request is slow and resource-intensive, and therefore does not scale well.
+</Note>
+
+Request the first page:
+
+```bash
+curl 'https://api.blaxel.ai/v0/agents?limit=50' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+The response includes a `data` array and a `meta` object:
+
+```json
+{
+  "data": [ ... ],
+  "meta": {
+    "hasMore": true,
+    "nextCursor": "...",
+    "total": 312
+  }
+}
+```
+
+Pass `meta.nextCursor` as `cursor` on the next request and repeat until `meta.hasMore` is `false`:
+
+```bash
+curl 'https://api.blaxel.ai/v0/agents?limit=50&cursor=NEXT_CURSOR' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+For more information, refer to the [API reference documentation](/api-reference/introduction#pagination).
+
 ## Customize the agent deployment
 
 You can set custom parameters for an agent deployment (e.g. specify the agent name, etc.) in the `blaxel.toml` file at the root of your directory.

--- a/Functions/Create-MCP-server.mdx
+++ b/Functions/Create-MCP-server.mdx
@@ -220,6 +220,49 @@ The remaining fields in *package.json* follow standard JavaScript/TypeScript pro
 </Accordion>
 </AccordionGroup>
 
+## List MCP servers
+
+To retrieve all MCP servers in your workspace, use the Management API list endpoint with pagination.
+
+<Note>
+  Pagination is recommended for list operations because retrieving all available resources in a single request is slow and resource-intensive, and therefore does not scale well.
+</Note>
+
+Request the first page:
+
+```bash
+curl 'https://api.blaxel.ai/v0/functions?limit=50' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+The response includes a `data` array and a `meta` object:
+
+```json
+{
+  "data": [ ... ],
+  "meta": {
+    "hasMore": true,
+    "nextCursor": "...",
+    "total": 36
+  }
+}
+```
+
+Pass `meta.nextCursor` as `cursor` on the next request and repeat until `meta.hasMore` is `false`:
+
+```bash
+curl 'https://api.blaxel.ai/v0/functions?limit=50&cursor=NEXT_CURSOR' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+<Tip>
+  For accounts with multiple workspaces, specify the workspace as an additional request parameter, such as `?workspace=WORKSPACE_NAME&...`, or via an additional `X-Blaxel-Workspace: WORKSPACE_NAME` header in the request.
+</Tip>
+
+For more information, refer to the [API reference documentation](/api-reference/introduction#pagination).
+
 <Card title="Deploy your MCP server" icon="rocket" href="/Functions/Deploy-a-function">
 Read our complete guide for deploying your custom MCP server on Blaxel.
 </Card>

--- a/Jobs/Deploy-a-job.mdx
+++ b/Jobs/Deploy-a-job.mdx
@@ -238,6 +238,49 @@ The **Blaxel Console** \> **Dashboard** displays detailed job metrics, including
 
 ![image](./Overview/job-metrics.webp)
 
+## List jobs
+
+To retrieve all jobs in your workspace, use the Management API list endpoint with pagination.
+
+<Note>
+  Pagination is recommended for list operations because retrieving all available resources in a single request is slow and resource-intensive, and therefore does not scale well.
+</Note>
+
+Request the first page:
+
+```bash
+curl 'https://api.blaxel.ai/v0/jobs?limit=50' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+The response includes a `data` array and a `meta` object:
+
+```json
+{
+  "data": [ ... ],
+  "meta": {
+    "hasMore": true,
+    "nextCursor": "...",
+    "total": 47
+  }
+}
+```
+
+Pass `meta.nextCursor` as `cursor` on the next request and repeat until `meta.hasMore` is `false`:
+
+```bash
+curl 'https://api.blaxel.ai/v0/jobs?limit=50&cursor=NEXT_CURSOR' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+<Tip>
+  For accounts with multiple workspaces, specify the workspace as an additional request parameter, such as `?workspace=WORKSPACE_NAME&...`, or via an additional `X-Blaxel-Workspace: WORKSPACE_NAME` header in the request.
+</Tip>
+
+For more information, refer to the [API reference documentation](/api-reference/introduction#pagination).
+
 ## Deploy with a Dockerfile
 
 While Blaxel uses predefined, optimized container images to build and deploy your code, you can also deploy your workload using your own [Dockerfile](https://docs.docker.com/reference/dockerfile/).

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -368,6 +368,45 @@ sandbox = await SandboxInstance.get("my-sandbox")
   Complete code examples demonstrating all operations are available on Blaxel's GitHub: [in TypeScript](https://github.com/blaxel-ai/sdk-typescript/tree/main/tests/sandbox), [in Python](https://github.com/blaxel-ai/sdk-python/tree/main/tests/integration/sandbox), and [in Go](https://github.com/blaxel-ai/sdk-go/tree/main/integration_tests).
 </Tip>
 
+## List sandboxes
+
+To retrieve all sandboxes in your workspace, use the Management API list endpoint with pagination.
+
+<Note>
+  Pagination is recommended for list operations because retrieving all available resources in a single request is slow and resource-intensive, and therefore does not scale well.
+</Note>
+
+Request the first page:
+
+```bash
+curl 'https://api.blaxel.ai/v0/sandboxes?limit=50' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+The response includes a `data` array and a `meta` object:
+
+```json
+{
+  "data": [ ... ],
+  "meta": {
+    "hasMore": true,
+    "nextCursor": "...",
+    "total": 312
+  }
+}
+```
+
+Pass `meta.nextCursor` as `cursor` on the next request and repeat until `meta.hasMore` is `false`:
+
+```bash
+curl 'https://api.blaxel.ai/v0/sandboxes?limit=50&cursor=NEXT_CURSOR' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+For more information, refer to the [API reference documentation](/api-reference/introduction#pagination).
+
 ## Delete a sandbox
 
 <Note>

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -405,6 +405,10 @@ curl 'https://api.blaxel.ai/v0/sandboxes?limit=50&cursor=NEXT_CURSOR' \
   -H 'Blaxel-Version: 2026-04-28'
 ```
 
+<Tip>
+  For accounts with multiple workspaces, specify the workspace as an additional request parameter, such as `?workspace=WORKSPACE_NAME&...`, or via an additional `X-Blaxel-Workspace: WORKSPACE_NAME` header in the request.
+</Tip>
+
 For more information, refer to the [API reference documentation](/api-reference/introduction#pagination).
 
 ## Delete a sandbox

--- a/Sandboxes/best-practices.mdx
+++ b/Sandboxes/best-practices.mdx
@@ -99,6 +99,11 @@ Instead of writing scripts to manually filter and delete sandboxes, use [expirat
 
 The sandbox metadata also includes a read-only parameter, `expiresIn`, that computes the number of seconds until a sandbox is terminated due to its TTL or lifecycle policy.
 
+## Use pagination for sandbox listings
+
+Requesting a list of all sandboxes in a single API call forces the platform to scan the full workspace, which is slow and resource-intensive at scale. Use the `cursor` and `limit` parameters to [retrieve sandboxes in pages](/Sandboxes/Overview#list-sandboxes) instead.
+
+
 ## Reduce cold start times with a pre-warmed pool
 
 For workloads with heavy images, you can maintain a pool of pre-warmed sandboxes to serve requests with near-zero latency.

--- a/Volumes/Overview.mdx
+++ b/Volumes/Overview.mdx
@@ -218,6 +218,53 @@ Resize a volume by calling:
 
 ## List volumes
 
+To retrieve all volumes in your workspace, use the Management API list endpoint with pagination.
+
+<Note>
+  Pagination is recommended for list operations because retrieving all available resources in a single request is slow and resource-intensive, and therefore does not scale well.
+</Note>
+
+Request the first page:
+
+```bash
+curl 'https://api.blaxel.ai/v0/volumes?limit=50' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+The response includes a `data` array and a `meta` object:
+
+```json
+{
+  "data": [ ... ],
+  "meta": {
+    "hasMore": true,
+    "nextCursor": "...",
+    "total": 18
+  }
+}
+```
+
+Pass `meta.nextCursor` as `cursor` on the next request and repeat until `meta.hasMore` is `false`:
+
+```bash
+curl 'https://api.blaxel.ai/v0/volumes?limit=50&cursor=NEXT_CURSOR' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+<Tip>
+  For accounts with multiple workspaces, specify the workspace as an additional request parameter, such as `?workspace=WORKSPACE_NAME&...`, or via an additional `X-Blaxel-Workspace: WORKSPACE_NAME` header in the request.
+</Tip>
+
+For more information, refer to the [API reference documentation](/api-reference/introduction#pagination).
+
+It is also possible to list all drives in a workspace using the SDKs.
+
+<Note>
+  This approach does not currently support pagination and is therefore not recommended when working with large lists.
+</Note>
+
 <CodeGroup>
 ```typescript TypeScript
 const volumes = await VolumeInstance.list()
@@ -237,7 +284,6 @@ You can use labels for filtering volumes in the Blaxel CLI or Blaxel Console:
 ```shell
 # Get volumes with specific label (e.g., env=test)
 bl get volumes -o json | jq -r '.[] | select(.metadata.labels.env == "test") | .metadata.name'
-```
 
 ## Use volumes with sandboxes and agents
 

--- a/Volumes/Overview.mdx
+++ b/Volumes/Overview.mdx
@@ -259,7 +259,7 @@ curl 'https://api.blaxel.ai/v0/volumes?limit=50&cursor=NEXT_CURSOR' \
 
 For more information, refer to the [API reference documentation](/api-reference/introduction#pagination).
 
-It is also possible to list all drives in a workspace using the SDKs.
+It is also possible to list all volumes in a workspace using the SDKs.
 
 <Note>
   This approach does not currently support pagination and is therefore not recommended when working with large lists.
@@ -284,6 +284,7 @@ You can use labels for filtering volumes in the Blaxel CLI or Blaxel Console:
 ```shell
 # Get volumes with specific label (e.g., env=test)
 bl get volumes -o json | jq -r '.[] | select(.metadata.labels.env == "test") | .metadata.name'
+```
 
 ## Use volumes with sandboxes and agents
 

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -106,3 +106,51 @@ Update your client to use a version from the table below.
     </tr>
   </tbody>
 </table>
+
+## Pagination
+
+<Warning>
+  This pagination feature is currently only available for the Management API.
+</Warning>
+
+List operations on the Management API return paginated results. Each response includes a `data` array and a `meta` object with cursor information for fetching subsequent pages.
+
+<Note>Pagination requires `Blaxel-Version: 2026-04-28` or later. Requests without this header use the earliest stable version, which returns a bare array without pagination metadata.</Note>
+
+### Request parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `cursor` | `string` | Opaque cursor returned by a previous response's meta.nextCursor. Only valid for the same query (workspace + filters); the server rejects cursors bound to a different query or older than 24h. Omit on the first page. |
+| `limit` | `integer` | Maximum number of items to return per page. Defaults to 50, maximum `200`. |
+| `sort` | `string` | Sort order. Options: `createdAt:desc` (default), `createdAt:asc`, `name:asc`, `name:desc`. |
+
+### Response metadata
+
+Each paginated response includes a `meta` object:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `hasMore` | `boolean` | `true` when additional pages are available. |
+| `nextCursor` | `string` | Opaque cursor to pass as `cursor` on the next request. Empty when there are no more pages. |
+| `total` | `integer` | Total number of items in the workspace, ignoring filters. |
+
+### Fetch pages manually
+
+Request the first page:
+
+```bash
+curl 'https://api.blaxel.ai/v0/agents?limit=50' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+The response includes `meta.nextCursor`. Pass it as `cursor` to fetch the next page:
+
+```bash
+curl 'https://api.blaxel.ai/v0/agents?limit=50&cursor=NEXT_CURSOR' \
+  -H 'X-Blaxel-Authorization: Bearer YOUR-API-KEY' \
+  -H 'Blaxel-Version: 2026-04-28'
+```
+
+Continue fetching pages until `meta.hasMore` is `false`.

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -110,12 +110,14 @@ Update your client to use a version from the table below.
 ## Pagination
 
 <Warning>
-  This pagination feature is currently only available for the Management API.
+  Pagination is currently only available for the Management API.
 </Warning>
 
 List operations on the Management API return paginated results. Each response includes a `data` array and a `meta` object with cursor information for fetching subsequent pages.
 
-<Note>Pagination requires `Blaxel-Version: 2026-04-28` or later. Requests without this header use the earliest stable version, which returns a bare array without pagination metadata.</Note>
+<Note>
+  Pagination requires `Blaxel-Version: 2026-04-28` or later. Requests without this header use the earliest stable version, which returns a bare array without pagination metadata.
+</Note>
 
 ### Request parameters
 
@@ -124,6 +126,10 @@ List operations on the Management API return paginated results. Each response in
 | `cursor` | `string` | Opaque cursor returned by a previous response's meta.nextCursor. Only valid for the same query (workspace + filters); the server rejects cursors bound to a different query or older than 24h. Omit on the first page. |
 | `limit` | `integer` | Maximum number of items to return per page. Defaults to 50, maximum `200`. |
 | `sort` | `string` | Sort order. Options: `createdAt:desc` (default), `createdAt:asc`, `name:asc`, `name:desc`. |
+
+<Tip>
+  For accounts with multiple workspaces, specify the workspace as an additional request parameter, such as `?workspace=WORKSPACE_NAME&...`, or via an additional `X-Blaxel-Workspace: WORKSPACE_NAME` header in the request.
+</Tip>
 
 ### Response metadata
 


### PR DESCRIPTION
Fixes ENG-3288

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds cursor-based pagination documentation (curl examples, response format, workspace parameter tips) to multiple resource pages (agents, drives, functions, jobs, sandboxes, volumes) and a new Pagination section to the API reference introduction.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7716ea4d1d61c02b7cec3c8dd6c0ce7e75dbc954.</sup>
<!-- /MENDRAL_SUMMARY -->