### PR TITLE
docs(sandboxes): document clearing TTL and lifecycle policies (ENG-3189)

### DIFF
--- a/Sandboxes/Expiration.mdx
+++ b/Sandboxes/Expiration.mdx
@@ -149,3 +149,49 @@ await SandboxInstance.update_lifecycle(
 ```
 
 </CodeGroup>
+
+## Clear sandbox expiry rules
+
+To make a sandbox persist again, clear its TTL or lifecycle policies. Clearing does not recreate the sandbox or affect its filesystem.
+
+Pass `null` (or an empty string) to `updateTtl` to remove the TTL:
+
+<CodeGroup>
+
+```typescript TypeScript
+import { SandboxInstance } from "@blaxel/core";
+
+// Clear the sandbox TTL
+const sandbox = await SandboxInstance.updateTtl("my-sandbox", null);
+```
+
+
+```python Python
+from blaxel.core import SandboxInstance
+
+# Clear the sandbox TTL
+sandbox = await SandboxInstance.update_ttl("my-sandbox", None)
+```
+
+</CodeGroup>
+
+Pass `null` to `updateLifecycle` to remove all expiration policies:
+
+<CodeGroup>
+
+```typescript TypeScript
+import { SandboxInstance } from "@blaxel/core";
+
+// Remove all expiration policies
+await SandboxInstance.updateLifecycle("my-sandbox", null);
+```
+
+
+```python Python
+from blaxel.core import SandboxInstance
+
+# Remove all expiration policies
+await SandboxInstance.update_lifecycle("my-sandbox", None)
+```
+
+</CodeGroup>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,14 @@ description: 'Chronological log of all Blaxel platform updates, new feature rele
   [Subscribe to this changelog's RSS feed](https://docs.blaxel.ai/changelog/rss.xml) for automated notifications of platform changes and new features.
 </Tip>
 
+<Update label="2026-06-19">
+
+### Clear sandbox TTL and lifecycle policies
+
+The SDKs can now clear a sandbox's expiration rules without recreating it. Pass `null`/`None` (or an empty string for the TTL) to `updateTtl` and `updateLifecycle` to make a sandbox persist again. See [Clear sandbox expiry rules](/Sandboxes/Expiration#clear-sandbox-expiry-rules).
+
+</Update>
+
 <Update label="2026-06-13">
 
 ### Refreshed Billing Explorer experience


### PR DESCRIPTION
## What

Documents the new SDK capability to clear a sandbox's expiration rules without recreating it.

## Why

The TypeScript, Python, and Go SDKs now let `updateTtl`/`updateLifecycle` accept `null`/`None`/`nil` (and an empty string for the TTL) to remove an existing TTL or lifecycle configuration. This was previously undocumented.

Code PRs: sdk-typescript#350, sdk-python#173, sdk-go#43. Linear: ENG-3189.

## Changes

- `Sandboxes/Expiration.mdx`: new "Clear sandbox expiry rules" section with TypeScript and Python examples for clearing the TTL and the lifecycle policies. Notes that clearing does not recreate the sandbox or touch its filesystem.
- `changelog.mdx`: entry dated 2026-06-19 linking to the new section.

## Validation

`npx mint broken-links` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds documentation for clearing sandbox TTL and lifecycle policies via `null`/`None` in SDK methods, plus a corresponding changelog entry.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 235d0b311bd5eda22e5d05efedd3258e4ba79059.</sup>
<!-- /MENDRAL_SUMMARY -->