### PR TITLE
chore: auto-update api docs from upstream

### DIFF
--- a/api-reference/controlplane.yml
+++ b/api-reference/controlplane.yml
@@ -204,6 +204,154 @@ components:
             type: string
             description: Subject type (user or service_account)
             example: user
+    AppRevision:
+      type: object
+      description: A single application revision containing the deployed image and
+        configuration
+      properties:
+        createdAt:
+          type: string
+          description: When this revision was created
+        createdBy:
+          type: string
+          description: Who created this revision
+        envs:
+          type: array
+          description: Environment variables for this revision
+          items:
+            $ref: '#/components/schemas/Env'
+        id:
+          type: string
+          description: Unique revision identifier
+        image:
+          type: string
+          description: Container image for this revision (mandatory)
+        memory:
+          type: integer
+          description: Memory allocation in megabytes. Determines CPU allocation (CPU
+            = memory / 2048).
+          example: 2048
+        port:
+          type: integer
+          description: Port the application listens on for this revision (default
+            uses spec-level port or 8080)
+          example: 8080
+      required:
+      - image
+    AppRevisionConfiguration:
+      type: object
+      description: Routing configuration controlling which revision is active and
+        canary traffic splitting
+      properties:
+        active:
+          type: string
+          description: Active revision id
+        canary:
+          type: string
+          description: Canary revision id
+        canaryPercent:
+          type: integer
+          description: Canary revision percent (0-100)
+          example: 10
+        stickySessionTtl:
+          type: integer
+          description: Sticky session TTL in seconds (0 = disabled)
+          example: 0
+        traffic:
+          type: integer
+          description: Traffic percentage for deployment
+          example: 100
+    AppRevisions:
+      type: array
+      items:
+        $ref: '#/components/schemas/AppRevision'
+    AppUrl:
+      type: object
+      description: A single URL entry for the application. If the domain is a wildcard
+        custom domain (e.g. *.sandbox.vybe.build), use subdomain to pick a specific
+        subdomain. If the domain is a direct custom domain (e.g. app.vybe.build),
+        subdomain is not needed.
+      properties:
+        domain:
+          type: string
+          description: Custom domain (must be a verified custom domain in the workspace).
+            Can be a wildcard domain (e.g. sandbox.vybe.build registered as *.sandbox.vybe.build)
+            or a direct domain (e.g. app.vybe.build).
+          example: app.example.com
+        subdomain:
+          type: string
+          description: Subdomain to use with a wildcard custom domain (optional)
+          example: www
+      required:
+      - domain
+    AppUrls:
+      type: array
+      description: URL configuration for the application. Each entry defines a custom
+        URL through which the application is accessible. The domain must be a verified
+        custom domain in the workspace.
+      items:
+        $ref: '#/components/schemas/AppUrl'
+    Application:
+      type: object
+      description: Long-running application deployment that runs your custom code
+        as a publicly accessible endpoint. Applications are always public and use
+        mk3 generation.
+      properties:
+        events:
+          $ref: '#/components/schemas/CoreEvents'
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        spec:
+          $ref: '#/components/schemas/ApplicationSpec'
+        status:
+          type: string
+          description: Application status computed from events
+          readOnly: true
+      required:
+      - metadata
+      - spec
+    ApplicationList:
+      type: object
+      description: Cursor-paginated list of applications. Returned starting with API
+        version 2026-04-28; older API versions return a bare array of applications
+        instead.
+      properties:
+        data:
+          type: array
+          description: Page of applications.
+          items:
+            $ref: '#/components/schemas/Application'
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
+    ApplicationSpec:
+      type: object
+      description: Configuration for an application including revision management,
+        URL routing, and deployment region
+      properties:
+        enabled:
+          type: boolean
+          description: When false, the application is disabled and will not serve
+            requests
+          example: true
+          default: true
+        port:
+          type: integer
+          description: Port the application listens on (default 8080)
+          example: 8080
+        region:
+          type: string
+          description: Region where the application is deployed (e.g. us-pdx-1, eu-lon-1)
+          example: us-pdx-1
+        revision:
+          $ref: '#/components/schemas/AppRevisionConfiguration'
+        revisions:
+          $ref: '#/components/schemas/AppRevisions'
+        urls:
+          $ref: '#/components/schemas/AppUrls'
+    Applications:
+      type: array
+      items:
+        $ref: '#/components/schemas/Application'
     Configuration:
       type: object
       description: Configuration
@@ -418,13 +566,13 @@ components:
           - failed
           readOnly: true
           example: verified
-        subdomains:
+        subjectAlternativeNames:
           type: array
-          description: List of subdomains (previews) currently using this custom domain.
-            Only populated on GET /customdomains/{domainName}.
+          description: Subject Alternative Names (SANs) for the ACM certificate. Only
+            applicable for application domains.
           items:
-            $ref: '#/components/schemas/CustomDomainSubdomain'
-          readOnly: true
+            type: object
+            additionalProperties: true
         txtRecords:
           type: object
           description: Map of TXT record names to values for domain verification
@@ -434,26 +582,6 @@ components:
           type: string
           description: Error message if verification failed
           readOnly: true
-      x-stainless-ignore: true
-    CustomDomainSubdomain:
-      type: object
-      description: A subdomain (preview) using a custom domain
-      properties:
-        previewName:
-          type: string
-          description: Preview name
-        resourceName:
-          type: string
-          description: Resource name
-        resourceType:
-          type: string
-          description: Resource type (e.g., sandbox)
-        subdomain:
-          type: string
-          description: Subdomain prefix used for routing
-        url:
-          type: string
-          description: Full URL of the preview on this custom domain
       x-stainless-ignore: true
     Drive:
       type: object
@@ -888,6 +1016,8 @@ components:
           description: Minimum instances to keep warm. Set to 1+ to eliminate cold
             starts, 0 for scale-to-zero.
           example: 0
+        ports:
+          $ref: '#/components/schemas/Ports'
         transport:
           type: string
           description: Transport compatibility for the MCP, can be "websocket" or
@@ -1926,14 +2056,10 @@ components:
         hasMore:
           type: boolean
           description: True when more pages are available beyond the current one.
-          x-stainless-pagination-property:
-            purpose: has_next_page
         nextCursor:
           type: string
           description: Opaque cursor to pass back as the `cursor` query param for
             the next page. Empty when there are no more pages.
-          x-stainless-pagination-property:
-            purpose: next_cursor_field
         total:
           type: integer
           description: Total number of items in the workspace, ignoring the current
@@ -2218,6 +2344,7 @@ components:
       - function
       - agent
       - sandbox
+      - application
     PolicyResourceTypes:
       type: array
       description: PolicyResourceTypes is a local type that wraps a slice of PolicyResourceType
@@ -3588,6 +3715,11 @@ components:
             agents:update: Update agents
             apiKey:list: List API keys
             apiKey:write: Create and delete API keys
+            applications:create: Create applications
+            applications:delete: Delete applications
+            applications:get: Get application details
+            applications:list: List applications
+            applications:update: Update applications
             configurations:list: List configurations
             customdomains:create: Create custom domains
             customdomains:delete: Delete custom domains
@@ -3658,6 +3790,11 @@ components:
             agents:update: Update agents
             apiKey:list: List API keys
             apiKey:write: Create and delete API keys
+            applications:create: Create applications
+            applications:delete: Delete applications
+            applications:get: Get application details
+            applications:list: List applications
+            applications:update: Update applications
             configurations:list: List configurations
             customdomains:create: Create custom domains
             customdomains:delete: Delete custom domains
@@ -4006,6 +4143,314 @@ paths:
       summary: List all agent revisions
       tags:
       - agents
+  /applications:
+    get:
+      description: Returns applications deployed in the workspace. Each application
+        includes its deployment status, runtime configuration, and endpoint URL. Starting
+        with API version 2026-04-28 the response is wrapped in `{data, meta}` and
+        supports cursor pagination via the `cursor` and `limit` query parameters;
+        older versions keep returning a bare array with all applications.
+      operationId: ListApplications
+      parameters:
+      - $ref: '#/components/parameters/PaginationCursor'
+      - $ref: '#/components/parameters/PaginationLimit'
+      - $ref: '#/components/parameters/PaginationSort'
+      - $ref: '#/components/parameters/PaginationQuery'
+      - $ref: '#/components/parameters/PaginationAnchor'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationList'
+          description: successful operation
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized - Invalid or missing authentication credentials
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden - Insufficient permissions to list applications
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      security:
+      - OAuth2:
+        - applications:list
+      - ApiKeyAuth: []
+      summary: List all applications
+      tags:
+      - applications
+    post:
+      description: Creates a new application deployment. Applications are long-running
+        workloads that default to public access and mk3 generation.
+      operationId: CreateApplication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Application'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Application'
+          description: successful operation
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Bad request - Invalid application configuration
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized - Invalid or missing authentication credentials
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden - Insufficient permissions to create applications
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Conflict - Application with this name already exists
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      security:
+      - OAuth2:
+        - applications:create
+      - ApiKeyAuth: []
+      summary: Create application
+      tags:
+      - applications
+  /applications/{applicationName}:
+    delete:
+      description: Permanently deletes an application and all its deployment history.
+        The application endpoint will immediately stop responding. This action cannot
+        be undone.
+      operationId: DeleteApplication
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Application'
+          description: successful operation
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized - Invalid or missing authentication credentials
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden - Insufficient permissions to delete this application
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Not found - Application does not exist
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      security:
+      - OAuth2:
+        - applications:delete
+      - ApiKeyAuth: []
+      summary: Delete application
+      tags:
+      - applications
+    get:
+      description: Returns detailed information about an application including its
+        current deployment status, configuration, events history, and endpoint URL.
+      operationId: GetApplication
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Application'
+          description: successful operation
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized - Invalid or missing authentication credentials
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden - Insufficient permissions to view this application
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Not found - Application does not exist
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      security:
+      - OAuth2:
+        - applications:get
+      - ApiKeyAuth: []
+      summary: Get application
+      tags:
+      - applications
+    parameters:
+    - description: Unique name identifier of the application
+      in: path
+      name: applicationName
+      required: true
+      schema:
+        type: string
+    put:
+      description: Updates an application's configuration and triggers a new deployment.
+        Changes to runtime settings, environment variables, or scaling parameters
+        will be applied on the next deployment.
+      operationId: UpdateApplication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Application'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Application'
+          description: successful operation
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Bad request - Invalid application configuration
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized - Invalid or missing authentication credentials
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden - Insufficient permissions to update this application
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Not found - Application does not exist
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal server error
+      security:
+      - OAuth2:
+        - applications:update
+      - ApiKeyAuth: []
+      summary: Update application
+      tags:
+      - applications
+  /applications/{applicationName}/customdomains:
+    post:
+      description: Creates a new custom domain scoped to a specific application. After
+        creation, you must configure DNS records and verify domain ownership before
+        it becomes active.
+      operationId: CreateApplicationCustomDomain
+      parameters:
+      - description: Name of the application
+        in: path
+        name: applicationName
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomDomain'
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomDomain'
+          description: successful operation
+      security:
+      - OAuth2:
+        - customdomains:create
+      - ApiKeyAuth: []
+      summary: Create application custom domain
+      tags:
+      - customdomains
+      x-stainless-ignore: true
+  /applications/{applicationName}/revisions:
+    get:
+      operationId: ListApplicationRevisions
+      parameters:
+      - description: Name of the application
+        in: path
+        name: applicationName
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/RevisionMetadata'
+                type: array
+          description: successful operation
+      security:
+      - OAuth2:
+        - applications:list
+      - ApiKeyAuth: []
+      summary: List all application revisions
+      tags:
+      - applications
   /configuration:
     get:
       description: Returns global platform configuration including available regions,


### PR DESCRIPTION
Automated update of api docs

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Upstream API doc sync that fixes previously flagged typos, adds full Application resource support (schemas, CRUD endpoints, permissions), replaces `subdomains` with `subjectAlternativeNames` on CustomDomain, adds `ports` to MCP spec, and removes `x-stainless-pagination-property` annotations.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f755e018dda6e91fe5278bc41da172a07d428e35.</sup>
<!-- /MENDRAL_SUMMARY -->