### PR TITLE
feat: add info on sandbox firewall

### DIFF
--- a/Sandboxes/Proxy-domains.mdx
+++ b/Sandboxes/Proxy-domains.mdx
@@ -11,7 +11,7 @@ tag: "public preview"
 Domain filtering lets you control which external domains a sandbox can reach. You can define an allowlist (only listed domains are reachable) or a denylist (all domains except listed ones are reachable). Domain filtering and proxy routing are **independent configurations** — you do not need to duplicate domains across both. A domain can appear in the allowlist without having a proxy routing rule, and vice versa.
 
 <Warning>
-  Domain filtering relies on the sandbox's tools and libraries respecting the standard proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`). Traffic from tools that ignore proxy environment variables will not be filtered unless [routing-level enforcement](#routing-level-enforcement) is enabled.
+  Domain filtering relies on the sandbox's tools and libraries respecting the standard proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`). Traffic from tools that ignore proxy environment variables will not be filtered unless [domain filter enforcement](#domain-filter-enforcement) is enabled.
 </Warning>
 
 ## Allowlist
@@ -82,14 +82,14 @@ await SandboxInstance.create({
   When both `allowedDomains` and `forbiddenDomains` are set, `forbiddenDomains` takes precedence: a domain that appears in both lists will be blocked.
 </Note>
 
-## Routing-level enforcement
+## Domain filter enforcement
 
-By default, domain filtering depends on the sandbox's tools respecting `HTTP_PROXY` and `HTTPS_PROXY`. To enforce filtering even for tools that bypass those variables, add a `firewall` config with `rulesets: ["proxy"]`. This routes all egress traffic through the proxy at the network level, regardless of how the tool is configured:
+By default, domain filtering depends on the sandbox's tools respecting `HTTP_PROXY` and `HTTPS_PROXY`. To enforce filtering even for tools that bypass those variables, add a `firewall` config with `rulesets: ["proxy"]`. This forces all outbound traffic to flow through the proxy at the network level.
 
 <CodeGroup>
 
 ```typescript TypeScript
-await SandboxInstance.create({
+await SandboxInstance.createIfNotExists({
   name: "enforced-sandbox",
   image: "blaxel/base-image:latest",
   region: "us-was-1",
@@ -102,7 +102,7 @@ await SandboxInstance.create({
 ```
 
 ```python Python
-await SandboxInstance.create({
+await SandboxInstance.create_if_not_exists({
     "name": "enforced-sandbox",
     "image": "blaxel/base-image:latest",
     "region": "us-was-1",
@@ -117,7 +117,7 @@ await SandboxInstance.create({
 </CodeGroup>
 
 <Note>
-  Routing-level enforcement is not yet applied automatically when a proxy config is set. In a future release, it will be enabled by default whenever a proxy is configured.
+  Currently, this feature is not enforced automatically by the platform when a proxy is configured. In a future release, it will be automatically enforced whenever a proxy is configured.
 </Note>
 
 ## Firewall + proxy combined

--- a/Sandboxes/Proxy-domains.mdx
+++ b/Sandboxes/Proxy-domains.mdx
@@ -79,7 +79,7 @@ await SandboxInstance.create({
 </CodeGroup>
 
 <Note>
-  When both `allowedDomains` and `forbiddenDomains` are set, `forbiddenDomains` takes precedence: a domain that appears in both lists will be blocked.
+  When both `allowedDomains` and `forbiddenDomains` are set, `allowedDomains` takes precedence: a domain that appears in both lists will be allowed.
 </Note>
 
 ## Domain filter enforcement

--- a/Sandboxes/Proxy-domains.mdx
+++ b/Sandboxes/Proxy-domains.mdx
@@ -11,7 +11,7 @@ tag: "public preview"
 Domain filtering lets you control which external domains a sandbox can reach. You can define an allowlist (only listed domains are reachable) or a denylist (all domains except listed ones are reachable). Domain filtering and proxy routing are **independent configurations** — you do not need to duplicate domains across both. A domain can appear in the allowlist without having a proxy routing rule, and vice versa.
 
 <Warning>
-  Domain filtering relies on the sandbox's tools and libraries respecting the standard proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`). Traffic from tools that ignore these variables will not be filtered. Routing-level enforcement is planned for a future release.
+  Domain filtering relies on the sandbox's tools and libraries respecting the standard proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`). Traffic from tools that ignore proxy environment variables will not be filtered unless [routing-level enforcement](#routing-level-enforcement) is enabled.
 </Warning>
 
 ## Allowlist
@@ -80,6 +80,44 @@ await SandboxInstance.create({
 
 <Note>
   When both `allowedDomains` and `forbiddenDomains` are set, `forbiddenDomains` takes precedence: a domain that appears in both lists will be blocked.
+</Note>
+
+## Routing-level enforcement
+
+By default, domain filtering depends on the sandbox's tools respecting `HTTP_PROXY` and `HTTPS_PROXY`. To enforce filtering even for tools that bypass those variables, add a `firewall` config with `rulesets: ["proxy"]`. This routes all egress traffic through the proxy at the network level, regardless of how the tool is configured:
+
+<CodeGroup>
+
+```typescript TypeScript
+await SandboxInstance.create({
+  name: "enforced-sandbox",
+  image: "blaxel/base-image:latest",
+  region: "us-was-1",
+  network: {
+    firewall: { rulesets: ["proxy"] },
+    allowedDomains: ["httpbin.org"],
+    proxy: { routing: [] },
+  },
+});
+```
+
+```python Python
+await SandboxInstance.create({
+    "name": "enforced-sandbox",
+    "image": "blaxel/base-image:latest",
+    "region": "us-was-1",
+    "network": {
+        "firewall": {"rulesets": ["proxy"]},
+        "allowedDomains": ["httpbin.org"],
+        "proxy": {"routing": []},
+    },
+})
+```
+
+</CodeGroup>
+
+<Note>
+  Routing-level enforcement is not yet applied automatically when a proxy config is set. In a future release, it will be enabled by default whenever a proxy is configured.
 </Note>
 
 ## Firewall + proxy combined

--- a/Sandboxes/Proxy.mdx
+++ b/Sandboxes/Proxy.mdx
@@ -93,7 +93,14 @@ sandbox = await SandboxInstance.create({
 |---|---|---|
 | `allowedDomains` | `string[]` / `list[str]` | Allowlist — only these domains are reachable. Supports wildcards (`*.s3.amazonaws.com`). |
 | `forbiddenDomains` | `string[]` / `list[str]` | Denylist — all domains except these are reachable. Supports wildcards. If both are set, `forbiddenDomains` takes precedence. |
+| `firewall` | `FirewallConfig` | Routing-level enforcement config. When set, forces all egress traffic through the Blaxel proxy unconditionally. |
 | `proxy` | `ProxyConfig` | Proxy routing and bypass configuration. |
+
+### `FirewallConfig`
+
+| Field | Type | Description |
+|---|---|---|
+| `rulesets` | `string[]` / `list[str]` | Enforcement rules to apply. Pass `["proxy"]` to force all egress traffic through the Blaxel proxy at the network level. |
 
 ### `ProxyConfig`
 

--- a/Sandboxes/Proxy.mdx
+++ b/Sandboxes/Proxy.mdx
@@ -93,14 +93,14 @@ sandbox = await SandboxInstance.create({
 |---|---|---|
 | `allowedDomains` | `string[]` / `list[str]` | Allowlist — only these domains are reachable. Supports wildcards (`*.s3.amazonaws.com`). |
 | `forbiddenDomains` | `string[]` / `list[str]` | Denylist — all domains except these are reachable. Supports wildcards. If both are set, `forbiddenDomains` takes precedence. |
-| `firewall` | `FirewallConfig` | Routing-level enforcement config. When set, forces all egress traffic through the Blaxel proxy unconditionally. |
+| `firewall` | `FirewallConfig` | Proxy firewall configuration. |
 | `proxy` | `ProxyConfig` | Proxy routing and bypass configuration. |
 
 ### `FirewallConfig`
 
 | Field | Type | Description |
 |---|---|---|
-| `rulesets` | `string[]` / `list[str]` | Enforcement rules to apply. Pass `["proxy"]` to force all egress traffic through the Blaxel proxy at the network level. |
+| `rulesets` | `string[]` / `list[str]` | Domain filtering rules to apply. Set to `["proxy"]` to force all sandbox outbound traffic through the Blaxel proxy. |
 
 ### `ProxyConfig`
 

--- a/Sandboxes/Proxy.mdx
+++ b/Sandboxes/Proxy.mdx
@@ -92,7 +92,7 @@ sandbox = await SandboxInstance.create({
 | Field | Type | Description |
 |---|---|---|
 | `allowedDomains` | `string[]` / `list[str]` | Allowlist — only these domains are reachable. Supports wildcards (`*.s3.amazonaws.com`). |
-| `forbiddenDomains` | `string[]` / `list[str]` | Denylist — all domains except these are reachable. Supports wildcards. If both are set, `forbiddenDomains` takes precedence. |
+| `forbiddenDomains` | `string[]` / `list[str]` | Denylist — all domains except these are reachable. Supports wildcards. If both are set, `allowedDomains` takes precedence. |
 | `firewall` | `FirewallConfig` | Proxy firewall configuration. |
 | `proxy` | `ProxyConfig` | Proxy routing and bypass configuration. |
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -17,9 +17,9 @@ The SDKs can now clear a sandbox's expiration rules without recreating it. Pass 
 
 <Update label="2026-06-13">
 
-### Routing-level firewall enforcement for sandboxes
+### Proxy-based firewall support
 
-Sandboxes can now enforce domain filtering at the network level, rather than relying on tools respecting proxy environment variables. Set `firewall: { rulesets: ["proxy"] }` in the sandbox `network` config to route all egress traffic through the Blaxel proxy unconditionally — ensuring `allowedDomains` and `forbiddenDomains` rules apply even to tools that bypass `HTTP_PROXY`. Requires Python SDK ≥ 0.2.56 or TypeScript SDK ≥ 0.2.90. See [Domain filtering](/Sandboxes/Proxy-domains).
+Sandboxes can now enforce domain filtering at the network level.
 
 </Update>
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -17,6 +17,14 @@ The SDKs can now clear a sandbox's expiration rules without recreating it. Pass 
 
 <Update label="2026-06-13">
 
+### Routing-level firewall enforcement for sandboxes
+
+Sandboxes can now enforce domain filtering at the network level, rather than relying on tools respecting proxy environment variables. Set `firewall: { rulesets: ["proxy"] }` in the sandbox `network` config to route all egress traffic through the Blaxel proxy unconditionally — ensuring `allowedDomains` and `forbiddenDomains` rules apply even to tools that bypass `HTTP_PROXY`. Requires Python SDK ≥ 0.2.56 or TypeScript SDK ≥ 0.2.90. See [Domain filtering](/Sandboxes/Proxy-domains).
+
+</Update>
+
+<Update label="2026-06-13">
+
 ### Refreshed Billing Explorer experience
 
 <Frame>


### PR DESCRIPTION
Fixes ENG-3410

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds documentation for the sandbox firewall feature (`firewall: { rulesets: ["proxy"] }`) and corrects the precedence rule when both `allowedDomains` and `forbiddenDomains` are set (now states `allowedDomains` takes precedence).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f0729984d30060db9e35239e5c025dafdfe4f712.</sup>
<!-- /MENDRAL_SUMMARY -->