### PR TITLE
Document sandbox root storage

### DIFF
--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -129,6 +129,7 @@ const sandbox = await SandboxInstance.createIfNotExists({
   name: "my-sandbox",
   image: "blaxel/base-image:latest",  // public or custom image
   memory: 4096,    // in MB
+  storageMb: 102400,    // optional; disk-backed root storage in MB
   ports: [{ target: 3000, protocol: "HTTP" }],  // optional; ports to expose
   labels: { env: "dev", project: "my-project" }, // optional; labels
   region: "us-pdx-1"    // deployment region
@@ -146,6 +147,7 @@ async def main():
       "name": "my-sandbox",
       "image": "blaxel/base-image:latest",   # public or custom image
       "memory": 4096,   # in MB
+      "storage_mb": 102400,   # optional; disk-backed root storage in MB
       "ports": [{ "target": 3000 }],   # optional; ports to expose
       "labels": {"env": "dev", "project": "my-project"},  # optional; labels
       "region": "us-pdx-1"   # deployment region
@@ -168,6 +170,7 @@ const sandbox = await SandboxInstance.create({
   name: "my-sandbox",
   image: "blaxel/base-image:latest",   // public or custom image
   memory: 4096,   // in MB
+  storageMb: 102400,   // optional; disk-backed root storage in MB
   ports: [{ target: 3000, protocol: "HTTP" }],   // optional; ports to expose
   labels: { env: "dev", project: "my-project" }, // optional; labels
   region: "us-pdx-1"   // deployment region
@@ -184,6 +187,7 @@ async def main():
       "name": "my-sandbox",
       "image": "blaxel/base-image:latest",   # public or custom image
       "memory": 4096,   # in MB
+      "storage_mb": 102400,   # optional; disk-backed root storage in MB
       "ports": [{ "target": 3000 }],   # optional; ports to expose
       "labels": {"env": "dev", "project": "my-project"},  # optional; labels
       "region": "us-pdx-1"   # deployment region
@@ -244,7 +248,11 @@ For maximum performance, Blaxel sandboxes store part of their filesystem in memo
 
 Due to this, Blaxel sandboxes reserve, when possible, approximately 50% of the available memory for the `tmpfs` filesystem. More information on our implementation is available in this [blog post](https://blaxel.ai/blog/how-to-slash-sandbox-memory-usage-by-75-using-overlayfs).
 
-To avoid out-of-memory errors or if additional storage is required, one option is to add storage using [volumes](/Sandboxes/Volumes). However, this requires deleting and recreating the sandbox first. In addition, volumes are not as fast as the native in-memory filesystem.
+For write-heavy workloads, set `storageMb` (TypeScript/CLI) or `storage_mb` (Python) when creating the sandbox to provision disk-backed root storage without increasing memory. This storage is part of the sandbox root filesystem, is deleted with the sandbox, and is capped by your account's ephemeral-volume quota.
+
+`storageMb` cannot be combined with a persistent volume mounted at `/`. Use root storage for ephemeral root filesystem capacity, or use a volume at a subpath such as `/data` when data should persist independently from the sandbox lifecycle.
+
+Use [volumes](/Sandboxes/Volumes) when data needs to live at a specific mount path or persist independently from the sandbox lifecycle. Volumes require deleting and recreating the sandbox first, and are not as fast as the native in-memory filesystem.
 
 ### Ports
 

--- a/Sandboxes/best-practices.mdx
+++ b/Sandboxes/best-practices.mdx
@@ -19,7 +19,7 @@ The most efficient way to manage lifecycle is to let the sandbox suspend automat
 
 Choosing the right storage for your sandbox data is important, as it can impact your agent's performance, reliability, and overall consistency. Blaxel offers three options:
 
-- Sandbox filesystem: The sandbox itself has a stateful [filesystem](/Sandboxes/Filesystem) optimized for speed. Data stored here persists for as long as the sandbox exists in standby, but is erased when the sandbox is terminated.
+- Sandbox filesystem: The sandbox itself has a stateful [filesystem](/Sandboxes/Filesystem) optimized for speed. Data stored here persists for as long as the sandbox exists in standby, but is erased when the sandbox is terminated. Use `storageMb` / `storage_mb` at sandbox creation when the root filesystem needs more disk-backed capacity than the default memory-backed filesystem.
 
 - Volumes: [Volumes](/Volumes/Overview) provide longer-term, durable block storage that is decoupled from compute. Data stored on a volume survives even if the associated sandbox is terminated, and newly-created sandboxes can access the data by attaching to the same volume.
 
@@ -38,7 +38,7 @@ Here's a table to help you decide:
 | Access type | Single | Single | Multiple |
 | Hot-attach | N/A | No | Yes |
 | Interface | POSIX | POSIX | POSIX + S3 |
-| Size | ~50% of sandbox memory | User-defined at creation, expandable | No size limit |
+| Size | ~50% of sandbox memory by default; configurable with root storage | User-defined at creation, expandable | No size limit |
 | Optimized for | Data that doesn’t require high durability | Data that requires durability with high performance | Shared data |
 
 ## Upload many files efficiently

--- a/deployment-reference.mdx
+++ b/deployment-reference.mdx
@@ -60,6 +60,8 @@ The format of Blaxel's configuration file is described below.
 # [runtime]
 # memory (MB)
 # memory = 4096
+# sandbox root storage (MB, optional)
+# storageMb = 102400
 
 # job configuration
 # maxConcurrentTasks = 10

--- a/troubleshooting.mdx
+++ b/troubleshooting.mdx
@@ -103,17 +103,23 @@ To resolve this error, adjust the model's token usage policy. Token usage polici
 
 This error occurs when your sandbox runs out of storage space. This usually happens when your file storage requirements exceed the available memory since, for performance reasons, Blaxel sandboxes reserve, when possible, [approximately 50% of their available memory](/Sandboxes/Overview#memory-and-filesystem) for the filesystem.
 
-To resolve this error, you have two options:
+To resolve this error, choose the storage option that matches the workload:
+
+- Set `storageMb` (TypeScript/CLI) or `storage_mb` (Python) when creating the sandbox. This provisions disk-backed root storage without increasing memory and is the best fit for large temporary working directories, package installs, builds, and generated artifacts.
+
+    <Note>
+    Root storage cannot be combined with a persistent volume mounted at `/`.
+    </Note>
 
 - Increase the available memory allocation for the sandbox, which also increases the available filesystem storage.
 
     <Note>
-    Increasing memory also increases CPU allocation
+    Increasing memory also increases CPU allocation.
     - 8GB memory = 4 CPU cores
     - 16GB memory = 6 CPU cores
     </Note>
 
-- Add storage using [volumes](/Sandboxes/Volumes). Adding storage requires deleting and recreating the sandbox first.
+- Add storage using [volumes](/Sandboxes/Volumes) when data should live at a specific mount path or persist independently from the sandbox lifecycle. Adding storage requires deleting and recreating the sandbox first.
 
     <Note>
     Volumes are slower than the in-memory filesystem.


### PR DESCRIPTION
- Documents sandbox root storage for CLI, Python SDK, and TypeScript SDK users.
- Clarifies storageMb versus persistent volumes and root-volume conflicts.
- Adds ENOSPC troubleshooting guidance.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Documents the new `storageMb`/`storage_mb` sandbox creation parameter for disk-backed root storage across Overview, best-practices, deployment-reference, and troubleshooting pages. Adds ENOSPC guidance and clarifies root-storage vs volume trade-offs.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit efbe16a6ec59f2d3cd70a5a05341103198585cdd.</sup>
<!-- /MENDRAL_SUMMARY -->