### PR TITLE
fix: update firewall precedence rule

### DIFF
--- a/Sandboxes/Proxy-domains.mdx
+++ b/Sandboxes/Proxy-domains.mdx
@@ -79,7 +79,7 @@ await SandboxInstance.create({
 </CodeGroup>
 
 <Note>
-  When both `allowedDomains` and `forbiddenDomains` are set, `forbiddenDomains` takes precedence: a domain that appears in both lists will be blocked.
+  When both `allowedDomains` and `forbiddenDomains` are set, `allowedDomains` takes precedence: a domain that appears in both lists will be allowed.
 </Note>
 
 ## Firewall + proxy combined

--- a/Sandboxes/Proxy.mdx
+++ b/Sandboxes/Proxy.mdx
@@ -92,7 +92,7 @@ sandbox = await SandboxInstance.create({
 | Field | Type | Description |
 |---|---|---|
 | `allowedDomains` | `string[]` / `list[str]` | Allowlist — only these domains are reachable. Supports wildcards (`*.s3.amazonaws.com`). |
-| `forbiddenDomains` | `string[]` / `list[str]` | Denylist — all domains except these are reachable. Supports wildcards. If both are set, `forbiddenDomains` takes precedence. |
+| `forbiddenDomains` | `string[]` / `list[str]` | Denylist — all domains except these are reachable. Supports wildcards. If both are set, `allowedDomains` takes precedence. |
 | `proxy` | `ProxyConfig` | Proxy routing and bypass configuration. |
 
 ### `ProxyConfig`


### PR DESCRIPTION
Fixes ENG-3468

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Updates documentation to state that `allowedDomains` takes precedence over `forbiddenDomains` when both are set (previously documented as the opposite).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6a6982371a827af75a45cfb884086191e7c80d3b.</sup>
<!-- /MENDRAL_SUMMARY -->