### PR TITLE
docs(sandboxes): add Schedules page

### DIFF
--- a/Sandboxes/Schedules.mdx
+++ b/Sandboxes/Schedules.mdx
@@ -172,7 +172,24 @@ Deleting a schedule removes it from the underlying scheduler, so no further runs
 
 Each firing records one execution. The `statusCode` is the HTTP status returned when the command was submitted to the sandbox, not the command's own exit code: the scheduler does not wait for the command to finish. A 2xx or 3xx status means the command was accepted.
 
+List the execution history of a sandbox. It returns the runs of every schedule on the sandbox, newest first:
+
 <CodeGroup>
+
+```typescript TypeScript
+const executions = await sandbox.schedules.executions();
+
+for (const execution of executions) {
+  console.log(execution.scheduleId, execution.statusCode, execution.processName);
+}
+```
+
+```python Python
+executions = await sandbox.schedules.executions()
+
+for execution in executions:
+    print(execution.scheduleId, execution.statusCode, execution.processName)
+```
 
 ```bash REST
 curl "https://api.blaxel.ai/v0/sandboxes/my-sandbox/schedule-executions" \
@@ -181,7 +198,7 @@ curl "https://api.blaxel.ai/v0/sandboxes/my-sandbox/schedule-executions" \
 
 </CodeGroup>
 
-Each record carries the `processName` used to start the process, so you can look up its logs (see [Log streaming](/Sandboxes/Log-streaming)). History is a ring buffer per schedule: once it reaches `maxExecutions` (default 100), recording a new run drops the oldest.
+Each record carries `scheduleId`, `statusCode`, `executedAt`, and the `processName` used to start the process, so you can look up its logs (see [Log streaming](/Sandboxes/Log-streaming)). History is a ring buffer per schedule: once it reaches `maxExecutions` (default 100), recording a new run drops the oldest.
 
 ## Manage from the console
 

--- a/Sandboxes/Schedules.mdx
+++ b/Sandboxes/Schedules.mdx
@@ -202,10 +202,16 @@ Each record carries `scheduleId`, `statusCode`, `executedAt`, and the `processNa
 
 ## Manage from the console
 
-You can create and inspect schedules from the Blaxel Console, on the Schedules tab of a sandbox. The tab lists every schedule with its type, timing, and command, and shows the execution history for each one.
+You can create and inspect schedules from the [Blaxel Console](https://app.blaxel.ai), on the **Schedules** tab of a sandbox. The tab lists every schedule with its type, timing, and command, and shows the execution history for each one.
 
-## Resources
-
-- [Processes](/Sandboxes/Processes) to run commands in a sandbox on demand
-- [Log streaming](/Sandboxes/Log-streaming) to read the output of a scheduled run
-- [Standby control](/Sandboxes/Standby-control) for how `keepAlive` interacts with scale-to-zero
+<CardGroup>
+  <Card title="Processes and commands" icon="terminal" href="/Sandboxes/Processes">
+    Execute and manage processes in sandboxes.
+  </Card>
+  <Card title="Log streaming" icon="table-list" href="/Sandboxes/Log-streaming">
+    Access logs generated in a sandbox.
+  </Card>
+  <Card title="Expiration policies" icon="hourglass-half" href="/Sandboxes/Expiration">
+    Automatically delete sandboxes based on specific conditions.
+  </Card>
+</CardGroup>

--- a/Sandboxes/Schedules.mdx
+++ b/Sandboxes/Schedules.mdx
@@ -188,7 +188,7 @@ for (const execution of executions) {
 executions = await sandbox.schedules.executions()
 
 for execution in executions:
-    print(execution.scheduleId, execution.statusCode, execution.processName)
+    print(execution.schedule_id, execution.status_code, execution.process_name)
 ```
 
 ```bash REST

--- a/Sandboxes/Schedules.mdx
+++ b/Sandboxes/Schedules.mdx
@@ -1,0 +1,194 @@
+---
+title: 'Schedules'
+description: 'Run a command inside a Blaxel sandbox on a recurring cron, at a future date, or after a delay, with execution history for each run.'
+---
+
+Schedules run a process inside a sandbox automatically, without you triggering it from your client. Use them for recurring jobs (a nightly cleanup, a periodic sync), a one-off task at a future time, or a task that runs once after a delay. Each schedule fires a command through the sandbox process API and records the outcome in an execution history.
+
+A sandbox can hold up to 100 schedules.
+
+## Schedule types
+
+Every schedule has a `type` and a `value` that together define when it fires:
+
+- `cron`: recurring. `value` is a 5-field cron expression (e.g. `0 8 * * 1-5` for 8am on weekdays). Cron granularity is one minute.
+- `at`: one-off. `value` is an RFC 3339 datetime (e.g. `2026-07-01T09:00:00Z`). The schedule fires once, then deletes itself.
+- `sleep`: one-off. `value` is a duration from now (e.g. `2h`, `30m`, `7d`). On creation it is resolved to an `at` schedule, so a created `sleep` is returned with `type: at` and a concrete datetime.
+
+One-off schedules (`at` and `sleep`) are removed automatically after they fire. A `cron` schedule keeps firing until you delete it.
+
+## Schedule input
+
+The `input` object configures the process that each firing starts:
+
+| Field | Type | Description |
+|---|---|---|
+| `command` | string | Shell command to run inside the sandbox. Required. |
+| `name` | string | Optional process name, used to look up status and logs. |
+| `env` | object | Environment variables for the process. Values are encrypted at rest and masked in API responses. |
+| `workingDir` | string | Working directory for the command. |
+| `keepAlive` | boolean | Keep the sandbox awake (disable scale-to-zero) while the process runs. Defaults to `true`. |
+| `timeout` | integer | Process timeout in seconds. Defaults to `600`. Set to `0` for no timeout. |
+
+## Create a schedule
+
+Create a recurring schedule on an existing sandbox:
+
+<CodeGroup>
+
+```typescript TypeScript
+import { SandboxInstance } from "@blaxel/core";
+
+const sandbox = await SandboxInstance.get("my-sandbox");
+
+const schedule = await sandbox.schedules.create({
+  type: "cron",
+  value: "0 8 * * 1-5",
+  input: {
+    command: "python cleanup.py",
+    env: { TARGET: "staging" },
+  },
+});
+```
+
+```python Python
+from blaxel.core import SandboxInstance
+
+sandbox = await SandboxInstance.get("my-sandbox")
+
+schedule = await sandbox.schedules.create({
+    "type": "cron",
+    "value": "0 8 * * 1-5",
+    "input": {
+        "command": "python cleanup.py",
+        "env": {"TARGET": "staging"},
+    },
+})
+```
+
+```bash REST
+curl -X POST "https://api.blaxel.ai/v0/sandboxes/my-sandbox/schedules" \
+  -H "Authorization: Bearer $BL_API_KEY" \
+  -H "X-Blaxel-Workspace: $BL_WORKSPACE" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "cron",
+    "value": "0 8 * * 1-5",
+    "input": { "command": "python cleanup.py", "env": { "TARGET": "staging" } }
+  }'
+```
+
+</CodeGroup>
+
+Create a one-off task that runs once, 2 hours from now:
+
+<CodeGroup>
+
+```typescript TypeScript
+const schedule = await sandbox.schedules.create({
+  type: "sleep",
+  value: "2h",
+  input: { command: "python report.py" },
+});
+// Returned resolved to type "at" with a concrete datetime
+```
+
+```python Python
+schedule = await sandbox.schedules.create({
+    "type": "sleep",
+    "value": "2h",
+    "input": {"command": "python report.py"},
+})
+# Returned resolved to type "at" with a concrete datetime
+```
+
+```bash REST
+curl -X POST "https://api.blaxel.ai/v0/sandboxes/my-sandbox/schedules" \
+  -H "Authorization: Bearer $BL_API_KEY" \
+  -H "X-Blaxel-Workspace: $BL_WORKSPACE" \
+  -H "Content-Type: application/json" \
+  -d '{ "type": "sleep", "value": "2h", "input": { "command": "python report.py" } }'
+```
+
+</CodeGroup>
+
+## List and manage schedules
+
+Read, update, and delete schedules by their `id`:
+
+<CodeGroup>
+
+```typescript TypeScript
+// List every schedule on the sandbox
+const schedules = await sandbox.schedules.list();
+
+// Get one by id
+const schedule = await sandbox.schedules.get("schedule-0");
+
+// Update it
+await sandbox.schedules.update("schedule-0", {
+  type: "cron",
+  value: "0 9 * * 1-5",
+  input: { command: "python cleanup.py" },
+});
+
+// Delete it (stops further firings)
+await sandbox.schedules.delete("schedule-0");
+```
+
+```python Python
+# List every schedule on the sandbox
+schedules = await sandbox.schedules.list()
+
+# Get one by id
+schedule = await sandbox.schedules.get("schedule-0")
+
+# Update it
+await sandbox.schedules.update("schedule-0", {
+    "type": "cron",
+    "value": "0 9 * * 1-5",
+    "input": {"command": "python cleanup.py"},
+})
+
+# Delete it (stops further firings)
+await sandbox.schedules.delete("schedule-0")
+```
+
+```bash REST
+# List
+curl "https://api.blaxel.ai/v0/sandboxes/my-sandbox/schedules" \
+  -H "Authorization: Bearer $BL_API_KEY" -H "X-Blaxel-Workspace: $BL_WORKSPACE"
+
+# Delete
+curl -X DELETE "https://api.blaxel.ai/v0/sandboxes/my-sandbox/schedules/schedule-0" \
+  -H "Authorization: Bearer $BL_API_KEY" -H "X-Blaxel-Workspace: $BL_WORKSPACE"
+```
+
+</CodeGroup>
+
+Deleting a schedule removes it from the underlying scheduler, so no further runs fire.
+
+## Execution history
+
+Each firing records one execution. The `statusCode` is the HTTP status returned when the command was submitted to the sandbox, not the command's own exit code: the scheduler does not wait for the command to finish. A 2xx or 3xx status means the command was accepted.
+
+<CodeGroup>
+
+```bash REST
+curl "https://api.blaxel.ai/v0/sandboxes/my-sandbox/schedule-executions" \
+  -H "Authorization: Bearer $BL_API_KEY" -H "X-Blaxel-Workspace: $BL_WORKSPACE"
+```
+
+</CodeGroup>
+
+Each record carries the `processName` used to start the process, so you can look up its logs (see [Log streaming](/Sandboxes/Log-streaming)). History is a ring buffer per schedule: once it reaches `maxExecutions` (default 100), recording a new run drops the oldest.
+
+## Manage from the console
+
+You can create and inspect schedules from the Blaxel Console, on the Schedules tab of a sandbox. The tab lists every schedule with its type, timing, and command, and shows the execution history for each one.
+
+## Resources
+
+- [Processes](/Sandboxes/Processes) to run commands in a sandbox on demand
+- [Log streaming](/Sandboxes/Log-streaming) to read the output of a scheduled run
+- [Standby control](/Sandboxes/Standby-control) for how `keepAlive` interacts with scale-to-zero

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,11 +7,19 @@ description: 'Chronological log of all Blaxel platform updates, new feature rele
   [Subscribe to this changelog's RSS feed](https://docs.blaxel.ai/changelog/rss.xml) for automated notifications of platform changes and new features.
 </Tip>
 
+<Update label="2026-06-30">
+
+### Sandbox schedules
+
+Run a command inside a sandbox on a [fixed schedule](/Sandboxes/Schedules): recurring cron, at a future date, or after a delay.
+
+</Update>
+
 <Update label="2026-06-19">
 
 ### Clear sandbox TTL and lifecycle policies
 
-The SDKs can now clear a sandbox's expiration rules without recreating it. Pass `null`/`None` (or an empty string for the TTL) to `updateTtl` and `updateLifecycle` to make a sandbox persist again. See [Clear sandbox expiry rules](/Sandboxes/Expiration#clear-sandbox-expiry-rules).
+The SDKs can now [clear a sandbox's expiration rules](/Sandboxes/Expiration#clear-sandbox-expiry-rules) without recreating it. Pass `null`/`None` (or an empty string for the TTL) to `updateTtl` and `updateLifecycle` to make a sandbox persist again.
 
 </Update>
 

--- a/docs.json
+++ b/docs.json
@@ -42,6 +42,7 @@
               "Tutorials/OpenAI-Agents-SDK",
               "Sandboxes/Expiration",
               "Sandboxes/Processes",
+              "Sandboxes/Schedules",
               "Sandboxes/Filesystem",
               "Sandboxes/MCP",
               "Sandboxes/Codegen-tools",


### PR DESCRIPTION
## What

New docs page for **sandbox schedules**, under Sandboxes (after Processes).

Covers:
- Schedule types: `cron` (recurring), `at` (one-off datetime), `sleep` (delay, resolved to `at`)
- Schedule input fields (command, name, env, workingDir, keepAlive, timeout) with real defaults
- Create / list / update / delete, execution history, and console management
- Each example in TypeScript + Python + REST

## Note before merge

The SDK examples (`sandbox.schedules.create/list/get/update/delete`) mirror the preview resource pattern and use a payload aligned with the real REST contract (`{type, value, input}`). The SDK does not expose these yet ("integrate schedules in SDKs" is still pending). The REST and console flows are accurate today. Hold the merge until the SDK ships, or merge now knowing the TS/Python blocks only run once the SDK lands.

## Validation

- `docs.json` JSON valid, page added to nav
- `mint broken-links` -> no broken links found

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new documentation page for sandbox schedules covering schedule types (cron/at/sleep), input configuration, CRUD operations, execution history, and console management, with SDK and REST examples. Also adds the page to the docs navigation.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e388743ef13ca036344f788d0d38981f337ecf54.</sup>
<!-- /MENDRAL_SUMMARY -->