### PR TITLE
docs: minor edits to schedules page

### DIFF
--- a/Sandboxes/Schedules.mdx
+++ b/Sandboxes/Schedules.mdx
@@ -202,10 +202,16 @@ Each record carries `scheduleId`, `statusCode`, `executedAt`, and the `processNa
 
 ## Manage from the console
 
-You can create and inspect schedules from the Blaxel Console, on the Schedules tab of a sandbox. The tab lists every schedule with its type, timing, and command, and shows the execution history for each one.
+You can create and inspect schedules from the [Blaxel Console](https://app.blaxel.ai), on the **Schedules** tab of a sandbox. The tab lists every schedule with its type, timing, and command, and shows the execution history for each one.
 
-## Resources
-
-- [Processes](/Sandboxes/Processes) to run commands in a sandbox on demand
-- [Log streaming](/Sandboxes/Log-streaming) to read the output of a scheduled run
-- [Standby control](/Sandboxes/Standby-control) for how `keepAlive` interacts with scale-to-zero
+<CardGroup>
+  <Card title="Processes and commands" icon="terminal" href="/Sandboxes/Processes">
+    Execute and manage processes in sandboxes.
+  </Card>
+  <Card title="Log streaming" icon="table-list" href="/Sandboxes/Log-streaming">
+    Access logs generated in a sandbox.
+  </Card>
+  <Card title="Expiration policies" icon="hourglass-half" href="/Sandboxes/Expiration">
+    Automatically delete sandboxes based on specific conditions.
+  </Card>
+</CardGroup>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,11 +7,19 @@ description: 'Chronological log of all Blaxel platform updates, new feature rele
   [Subscribe to this changelog's RSS feed](https://docs.blaxel.ai/changelog/rss.xml) for automated notifications of platform changes and new features.
 </Tip>
 
+<Update label="2026-06-30">
+
+### Sandbox schedules
+
+Run a command inside a sandbox on a [fixed schedule](/Sandboxes/Schedules): recurring cron, at a future date, or after a delay.
+
+</Update>
+
 <Update label="2026-06-19">
 
 ### Clear sandbox TTL and lifecycle policies
 
-The SDKs can now clear a sandbox's expiration rules without recreating it. Pass `null`/`None` (or an empty string for the TTL) to `updateTtl` and `updateLifecycle` to make a sandbox persist again. See [Clear sandbox expiry rules](/Sandboxes/Expiration#clear-sandbox-expiry-rules).
+The SDKs can now [clear a sandbox's expiration rules](/Sandboxes/Expiration#clear-sandbox-expiry-rules) without recreating it. Pass `null`/`None` (or an empty string for the TTL) to `updateTtl` and `updateLifecycle` to make a sandbox persist again.
 
 </Update>
 


### PR DESCRIPTION
Fixes ENG-3488

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a changelog entry for sandbox schedules (2026-06-30), tweaks the existing 2026-06-19 changelog entry to inline a link, and replaces the plain bullet-list "Resources" section in Schedules.mdx with a `<CardGroup>` layout linking to related pages.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8481c511ad76c9e1d3bd8244d8c8aca6932190a7.</sup>
<!-- /MENDRAL_SUMMARY -->