### PR TITLE
docs: notify addition of sandbox telemetry

### DIFF
--- a/Security/Data-collection-and-privacy.mdx
+++ b/Security/Data-collection-and-privacy.mdx
@@ -85,3 +85,33 @@ export BL_ENABLE_OPENTELEMETRY=true    # Enable OpenTelemetry logging
 <Warning>
   Setting `DO_NOT_TRACK=1` has no effect on OpenTelemetry.
 </Warning>
+
+## Sandbox runtime error reporting
+
+The Blaxel sandbox runtime (`sandbox-api`) reports internal errors to Sentry. The data collected is limited to:
+
+- Error type and message
+- Stack trace
+- Environment
+- Release/version
+- Runtime context (e.g. goroutine info)
+
+Request context and user data are unconditionally stripped server-side before any data leaves the process. No request payloads, API keys, user identifiers, or IP addresses are transmitted.
+
+When telemetry is active, `sandbox-api` logs an explicit notice at startup.
+
+### Opt out
+
+Sandbox runtime telemetry is controlled independently from the SDK/CLI `DO_NOT_TRACK` variable. Use either of the following in your sandbox image configuration:
+
+```bash
+# Environment variable
+TELEMETRY_ENABLED=false
+
+# Startup flag in entrypoint script
+/usr/local/bin/sandbox-api --disable-telemetry &
+```
+
+<Warning>
+  `TELEMETRY_ENABLED` and `--disable-telemetry` only affect sandbox runtime error reporting. They have no effect on SDK/CLI error tracking (controlled by `DO_NOT_TRACK`) or OpenTelemetry tracing (controlled by `BL_ENABLE_OPENTELEMETRY`).
+</Warning>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -19,7 +19,7 @@ The SDKs can now clear a sandbox's expiration rules without recreating it. Pass 
 
 ### Sandbox runtime telemetry
 
-The sandbox API now reports internal errors to Sentry for improved reliability monitoring. All telemetry is anonymous. Opt out via the `--disable-telemetry` flag or by setting `TELEMETRY_ENABLED=false`. See [Sandbox runtime error reporting](/Security/Data-collection-and-privacy#sandbox-runtime-error-reporting).
+The sandbox API now reports internal errors to Sentry for improved reliability monitoring. All telemetry is anonymized. Opt out via the `--disable-telemetry` flag or by setting `TELEMETRY_ENABLED=false`. See [Sandbox runtime error reporting](/Security/Data-collection-and-privacy#sandbox-runtime-error-reporting).
 
 </Update>
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,19 +7,19 @@ description: 'Chronological log of all Blaxel platform updates, new feature rele
   [Subscribe to this changelog's RSS feed](https://docs.blaxel.ai/changelog/rss.xml) for automated notifications of platform changes and new features.
 </Tip>
 
-<Update label="2026-06-18">
-
-### Sandbox runtime telemetry
-
-The sandbox API now reports internal errors to Sentry for improved reliability monitoring. All telemetry is anonymous. Opt out via the `--disable-telemetry` flag or by setting `TELEMETRY_ENABLED=false`. See [Sandbox runtime error reporting](/Security/Data-collection-and-privacy#sandbox-runtime-error-reporting).
-
-</Update>
-
 <Update label="2026-06-19">
 
 ### Clear sandbox TTL and lifecycle policies
 
 The SDKs can now clear a sandbox's expiration rules without recreating it. Pass `null`/`None` (or an empty string for the TTL) to `updateTtl` and `updateLifecycle` to make a sandbox persist again. See [Clear sandbox expiry rules](/Sandboxes/Expiration#clear-sandbox-expiry-rules).
+
+</Update>
+
+<Update label="2026-06-18">
+
+### Sandbox runtime telemetry
+
+The sandbox API now reports internal errors to Sentry for improved reliability monitoring. All telemetry is anonymous. Opt out via the `--disable-telemetry` flag or by setting `TELEMETRY_ENABLED=false`. See [Sandbox runtime error reporting](/Security/Data-collection-and-privacy#sandbox-runtime-error-reporting).
 
 </Update>
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -7,6 +7,14 @@ description: 'Chronological log of all Blaxel platform updates, new feature rele
   [Subscribe to this changelog's RSS feed](https://docs.blaxel.ai/changelog/rss.xml) for automated notifications of platform changes and new features.
 </Tip>
 
+<Update label="2026-06-18">
+
+### Sandbox runtime telemetry
+
+The sandbox API now reports internal errors to Sentry for improved reliability monitoring. All telemetry is anonymous. Opt out via the `--disable-telemetry` flag or by setting `TELEMETRY_ENABLED=false`. See [Sandbox runtime error reporting](/Security/Data-collection-and-privacy#sandbox-runtime-error-reporting).
+
+</Update>
+
 <Update label="2026-06-19">
 
 ### Clear sandbox TTL and lifecycle policies


### PR DESCRIPTION
Fixes ENG-3489

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds documentation for sandbox runtime Sentry error reporting (data collected, opt-out mechanisms) and a corresponding changelog entry.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit aa9e85b483b1c479db3e5c2d0656a31268d68db8.</sup>
<!-- /MENDRAL_SUMMARY -->