### PR TITLE
docs: shorten sandbox schedules sidebar label to Schedule

### DIFF
--- a/Sandboxes/Schedules.mdx
+++ b/Sandboxes/Schedules.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Sandbox schedules'
+sidebarTitle: 'Schedule'
 description: 'Run a command inside a Blaxel sandbox on a recurring cron schedule, at a future datetime, or after a delay, with execution history for every run.'
 ---
 


### PR DESCRIPTION
Changes the sidebar label for the sandbox schedules page from "Sandbox schedules" to "Schedule" via `sidebarTitle`. The page title stays "Sandbox schedules" for SEO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `sidebarTitle` frontmatter field to shorten the sidebar label for the Sandbox Schedules page from "Sandbox schedules" to "Schedule".
> 
> <sup>Written by [Mendral](https://mendral.com) for commit db18de0f8102438e7b881654d8fe78f299e16b90.</sup>
<!-- /MENDRAL_SUMMARY -->