### PR TITLE
docs: move sandbox Schedule below Images in sidebar

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -42,7 +42,6 @@
               "Tutorials/OpenAI-Agents-SDK",
               "Sandboxes/Expiration",
               "Sandboxes/Processes",
-              "Sandboxes/Schedules",
               "Sandboxes/Filesystem",
               "Sandboxes/MCP",
               "Sandboxes/Codegen-tools",
@@ -67,6 +66,7 @@
               },
               "Sandboxes/Volumes",
               "Sandboxes/Templates",
+              "Sandboxes/Schedules",
               "Sandboxes/best-practices"
             ]
           },


### PR DESCRIPTION
Moves the **Schedule** page under Sandboxes so it sits right after **Images**, instead of higher up between Processes and Filesystem.

Sidebar-only reorder in `docs.json`, no content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/docs/pull/660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Moves the "Sandboxes/Schedules" entry in `docs.json` from its position between Processes and Filesystem to after Templates (near the end of the Sandboxes section).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ce3ca18959859230d25a18c728fa96854c5318c7.</sup>
<!-- /MENDRAL_SUMMARY -->