### PR TITLE
docs: update changelog for agent drive permissions

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -9,6 +9,14 @@ description: 'Chronological log of all Blaxel platform updates, new feature rele
 
 <Update label="2026-06-30">
 
+### Agent Drive permissions
+
+Added support for restricting read/write access to Agent Drive files and folders using [label-based ACL rules](/Agent-drive/Permissions).
+
+</Update>
+
+<Update label="2026-06-30">
+
 ### Pagination support in SDKs
 
 Added [pagination support](/sdk-reference/introduction#pagination) for list operations in all SDKs.


### PR DESCRIPTION
Fixes ENG-3552

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new changelog entry for Agent Drive permissions (label-based ACL rules) under the 2026-06-30 date.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 834e26af1159ee0ec88104417772f37bc294851e.</sup>
<!-- /MENDRAL_SUMMARY -->