### PR TITLE
docs: make SDK examples primary, update endpoints note

### DIFF
--- a/Agent-drive/Overview.mdx
+++ b/Agent-drive/Overview.mdx
@@ -240,11 +240,44 @@ bl drive mounts --sandbox my-sandbox
 
 ## List all drives
 
-To retrieve all drives in your workspace, use the Management API list endpoint with pagination.
+To retrieve all drives in your workspace, use the built-in SDK pagination helper functions.
 
 <Note>
   Pagination is recommended for list operations because retrieving all available resources in a single request is slow and resource-intensive, and therefore does not scale well.
 </Note>
+
+<CodeGroup>
+
+```tsx TypeScript
+import { DriveInstance } from "@blaxel/core";
+
+const drives = await DriveInstance.list({ limit: 50 });
+for await (const drive of drives) {
+  console.log(drive.name);
+}
+```
+
+```python Python
+import asyncio
+from blaxel.core.drive import DriveInstance
+
+async def main():
+    drives = await DriveInstance.list(limit=50)
+    async for drive in drives.auto_paging_iter():
+        print(drive.name)
+
+asyncio.run(main())
+```
+
+```bash CLI
+bl drive list
+```
+
+</CodeGroup>
+
+For more information on the SDK pagination helpers, refer to the [SDK reference documentation](/sdk-reference/introduction#pagination).
+
+Pagination is also available via the Management API list endpoint.
 
 Request the first page:
 
@@ -280,39 +313,6 @@ curl 'https://api.blaxel.ai/v0/drives?limit=50&cursor=NEXT_CURSOR' \
 </Tip>
 
 For more information, refer to the [API reference documentation](/api-reference/introduction#pagination).
-
-It is also possible to list all drives in a workspace using the SDKs, with built-in pagination helpers.
-
-<CodeGroup>
-
-```tsx TypeScript
-import { DriveInstance } from "@blaxel/core";
-
-const drives = await DriveInstance.list({ limit: 50 });
-for await (const drive of drives) {
-  console.log(drive.name);
-}
-```
-
-```python Python
-import asyncio
-from blaxel.core.drive import DriveInstance
-
-async def main():
-    drives = await DriveInstance.list(limit=50)
-    async for drive in drives.auto_paging_iter():
-        print(drive.name)
-
-asyncio.run(main())
-```
-
-```bash CLI
-bl drive list
-```
-
-</CodeGroup>
-
-For more information on the SDK pagination helpers, refer to the [SDK reference documentation](/sdk-reference/introduction#pagination).
 
 ## Get drive details
 

--- a/Volumes/Overview.mdx
+++ b/Volumes/Overview.mdx
@@ -218,11 +218,42 @@ Resize a volume by calling:
 
 ## List volumes
 
-To retrieve all volumes in your workspace, use the Management API list endpoint with pagination.
+To retrieve all volumes in your workspace, use the built-in SDK pagination helper functions.
 
 <Note>
   Pagination is recommended for list operations because retrieving all available resources in a single request is slow and resource-intensive, and therefore does not scale well.
 </Note>
+
+<CodeGroup>
+```typescript TypeScript
+import { VolumeInstance } from "@blaxel/core";
+
+const volumes = await VolumeInstance.list({ limit: 50 });
+for await (const volume of volumes) {
+  console.log(volume.name);
+}
+```
+
+```python Python
+import asyncio
+from blaxel.core import VolumeInstance
+
+async def main():
+    volumes = await VolumeInstance.list(limit=50)
+    async for volume in volumes.auto_paging_iter():
+        print(volume.name)
+
+asyncio.run(main())
+```
+
+```shell Blaxel CLI
+bl get volumes
+```
+</CodeGroup>
+
+For more information on the SDK pagination helpers, refer to the [SDK reference documentation](/sdk-reference/introduction#pagination).
+
+Pagination is also available via the Management API list endpoint.
 
 Request the first page:
 
@@ -258,37 +289,6 @@ curl 'https://api.blaxel.ai/v0/volumes?limit=50&cursor=NEXT_CURSOR' \
 </Tip>
 
 For more information, refer to the [API reference documentation](/api-reference/introduction#pagination).
-
-It is also possible to list all volumes in a workspace using the SDKs, with built-in pagination helpers.
-
-<CodeGroup>
-```typescript TypeScript
-import { VolumeInstance } from "@blaxel/core";
-
-const volumes = await VolumeInstance.list({ limit: 50 });
-for await (const volume of volumes) {
-  console.log(volume.name);
-}
-```
-
-```python Python
-import asyncio
-from blaxel.core import VolumeInstance
-
-async def main():
-    volumes = await VolumeInstance.list(limit=50)
-    async for volume in volumes.auto_paging_iter():
-        print(volume.name)
-
-asyncio.run(main())
-```
-
-```shell Blaxel CLI
-bl get volumes
-```
-</CodeGroup>
-
-For more information on the SDK pagination helpers, refer to the [SDK reference documentation](/sdk-reference/introduction#pagination).
 
 You can use labels for filtering volumes in the Blaxel CLI or Blaxel Console:
 

--- a/sdk-reference/introduction.mdx
+++ b/sdk-reference/introduction.mdx
@@ -210,7 +210,7 @@ The page object also exposes pagination state so you can inspect it directly: th
 
 ### Supported endpoints
 
-Pagination applies to list endpoints across SDK resources. Agent Drives, volumes, and job executions support it in all three SDKs. The TypeScript and Python SDKs also paginate a sandbox's schedules and schedule executions (`sandbox.schedules.list` and `sandbox.schedules.executions`). The Go SDK additionally exposes cursor pagination on its generated list endpoints, including agents, functions, jobs, models, policies, and sandboxes.
+Pagination applies to list endpoints across SDK resources. Agent Drives, volumes, and sandboxes support it in all three SDKs. The TypeScript and Python SDKs also paginate a sandbox's schedules and schedule executions (`sandbox.schedules.list` and `sandbox.schedules.executions`), as well as jobs, functions, and agents (`list_jobs`, `list_functions`, and `list_agents`). The Go SDK additionally exposes cursor pagination on its generated list endpoints, including agents, functions, jobs, models, policies, and sandboxes.
 
 <Note>
   You can also paginate results using the [API](/api-reference/introduction#pagination).


### PR DESCRIPTION
Fixes ENG-3554

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Reorders documentation in Agent Drives and Volumes overview pages to present SDK pagination examples before the raw API/curl examples, and updates the supported pagination endpoints note in the SDK reference introduction.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d918896e3dcc42b753631b00761c4ccd316adbbb.</sup>
<!-- /MENDRAL_SUMMARY -->