### PR TITLE
fix: revert "docs: improve Sandbox proxy page title for SEO (#651)"

### DIFF
--- a/Sandboxes/Proxy.mdx
+++ b/Sandboxes/Proxy.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Sandbox proxy routing and secrets injection"
+title: "Proxy"
 description: "Route outbound sandbox traffic through Blaxel's proxy with MITM header and body injection, inject secrets, and configure per-domain firewalls."
 tag: "public preview"
 ---


### PR DESCRIPTION
Fixes ENG-3567

This reverts commit b8b8cf3379f91a5581c2963c7ff6415ec54f7684.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Reverts the SEO-optimized page title for `Sandboxes/Proxy.mdx` back to the shorter "Proxy" title.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 42ca1839065b61ec71610bc6727aebd693097c50.</sup>
<!-- /MENDRAL_SUMMARY -->