### PR TITLE
docs: document upload limit

### DIFF
--- a/Sandboxes/Filesystem.mdx
+++ b/Sandboxes/Filesystem.mdx
@@ -280,6 +280,10 @@ The binary content to write can be provided as:
 - *File*: Web API File object
 - *Uint8Array*: Typed array containing binary data
 
+<Note>
+If you're calling the sandbox filesystem API directly over HTTP instead of using an SDK, a single request is capped at 8 MB. Requests larger than this are rejected with an HTTP 413 before they reach the sandbox. Therefore, if using HTTP, larger files must be uploaded in parts via the sandbox's multipart upload endpoints rather than in a single request. Blaxel SDKs handle this automatically: SDK functions like `write()`, `writeBinary()`, and `write_binary()` automatically split files over 5 MB and send via multipart upload in 5 MB chunks.
+</Note>
+
 ### Download file to host
 
 Download a file from the sandbox filesystem to the host:

--- a/Sandboxes/Filesystem.mdx
+++ b/Sandboxes/Filesystem.mdx
@@ -281,7 +281,7 @@ The binary content to write can be provided as:
 - *Uint8Array*: Typed array containing binary data
 
 <Note>
-If you're calling the sandbox filesystem API directly over HTTP instead of using an SDK, a single request is capped at 8 MB. Requests larger than this are rejected with an HTTP 413 before they reach the sandbox. Therefore, if using HTTP, larger files must be uploaded in parts via the sandbox's multipart upload endpoints rather than in a single request. Blaxel SDKs handle this automatically: SDK functions like `write()`, `writeBinary()`, and `write_binary()` automatically split files over 5 MB and send via multipart upload in 5 MB chunks.
+If you're calling the sandbox filesystem API directly over HTTP instead of using an SDK, a single request is capped at 5 MB. Requests larger than this are rejected with an HTTP 413 before they reach the sandbox. Therefore, if using HTTP, larger files must be uploaded in parts via the sandbox's multipart upload endpoints rather than in a single request. Blaxel SDKs handle this automatically: SDK functions like `write()`, `writeBinary()`, and `write_binary()` automatically split files over 5 MB and send via multipart upload in 5 MB chunks.
 </Note>
 
 ### Download file to host

--- a/Sandboxes/best-practices.mdx
+++ b/Sandboxes/best-practices.mdx
@@ -87,6 +87,8 @@ The TypeScript example uses the `adm-zip` package; any zip library works. The ex
 
 For small file sets, `writeTree()` (TypeScript) / `write_tree()` (Python) in the [filesystem API](/Sandboxes/Filesystem) writes multiple files in one batched call and is simpler. Use the zip pattern when the file count is large enough that per-call latency dominates.
 
+If the resulting zip archive exceeds 5 MB, `writeBinary()` / `write_binary()` automatically splits it into multipart uploads. Refer to [the sandbox filesystem documentation](/Sandboxes/Filesystem#write-binary-file) for details.
+
 ## Automate cleanup with TTLs
 
 In production, you will inevitably accumulate a long tail of sandboxes that will never be called upon again (completed tasks, abandoned user sessions, etc.). These can unnecessarily consume storage and add to your cost.

--- a/troubleshooting/error-codes.mdx
+++ b/troubleshooting/error-codes.mdx
@@ -49,3 +49,4 @@ Every error has a consistent JSON body and response header, as shown below:
 | `BAD_REQUEST` | 400 | No | Malformed request |
 | `USAGE_LIMIT_EXCEEDED` | 402 | No | Plan quota reached |
 | `POLICY_VIOLATION` | varies | No | Policy rule rejection |
+| `REQUEST_ENTITY_TOO_LARGE` | 413 | No | Request body exceeds 8 MB [upload limit](/Sandboxes/Filesystem#write-binary-file) |

--- a/troubleshooting/error-codes.mdx
+++ b/troubleshooting/error-codes.mdx
@@ -49,4 +49,4 @@ Every error has a consistent JSON body and response header, as shown below:
 | `BAD_REQUEST` | 400 | No | Malformed request |
 | `USAGE_LIMIT_EXCEEDED` | 402 | No | Plan quota reached |
 | `POLICY_VIOLATION` | varies | No | Policy rule rejection |
-| `REQUEST_ENTITY_TOO_LARGE` | 413 | No | Request body exceeds 8 MB [upload limit](/Sandboxes/Filesystem#write-binary-file) |
+| `REQUEST_ENTITY_TOO_LARGE` | 413 | No | Request body exceeds [upload limit](/Sandboxes/Filesystem#write-binary-file) |


### PR DESCRIPTION
Fixes ENG-3728

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Updates the documented single-request upload limit from 8 MB to 5 MB across all three files, making the cap and the SDK chunking threshold consistent at 5 MB.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 67106d14c892e40a2006c3f77053a306de25079b.</sup>
<!-- /MENDRAL_SUMMARY -->