### PR TITLE
docs: clarify multiple MCP options

### DIFF
--- a/Functions/Invoke-functions.mdx
+++ b/Functions/Invoke-functions.mdx
@@ -119,7 +119,7 @@ tools = await bl_tools(['blaxel-search'])
 Add the MCP server to MCP-aware applications and tools. This section has instructions for some popular applications.
 
 <Note>
-You must provide your [Blaxel API key](../Security) in the `Authorization` header. If you have access to multiple workspaces, include the workspace header as well.
+Blaxel MCP endpoints do not support OAuth. Use bearer-token authentication only. You must provide your [Blaxel API key](../Security) in the `Authorization` header. If you have access to multiple workspaces, include the workspace header as well.
 
 - Required: `Authorization: Bearer <APIKEY>`
 - Optional (multi-workspace): `X-Blaxel-Workspace: <WORKSPACE_NAME_OR_ID>`

--- a/Functions/Overview.mdx
+++ b/Functions/Overview.mdx
@@ -63,4 +63,4 @@ Manage environment variables and secrets for MCP servers.
 
 ## Related products
 
-MCP servers integrate with other Blaxel products. [Agents](/Agents/Overview) use MCP servers as tools, [sandboxes](/Sandboxes/Overview) include a [built-in MCP server](/Sandboxes/MCP) for agent-driven operations, and [model APIs](/Models/Overview) provide the LLM backbone for agent reasoning. See the [SDK reference](/sdk-reference/introduction) for programmatic access.
+MCP servers integrate with other Blaxel products. [Agents](/Agents/Overview) use MCP servers as tools, [sandboxes](/Sandboxes/Overview) include a [built-in MCP server](/Sandboxes/MCP) for agent-driven operations, and [model APIs](/Models/Overview) provide the LLM backbone for agent reasoning. See the [SDK reference](/sdk-reference/introduction) for programmatic access. Blaxel also offers [resource-management and documentation MCP servers](/skills-mcp) for your coding assistant.

--- a/Functions/oauth-flow.mdx
+++ b/Functions/oauth-flow.mdx
@@ -6,7 +6,11 @@ description: 'Set up a user-facing OAuth flow so end-users can authorize integra
 
 ---
 
-Some Blaxel integrations support [OAuth](https://oauth.net/2/)-based authentication. You can automate such a flow to allow multiple users (tenants) to go through an OAuth flow and each have their integration. 
+<Warning>
+  This page covers end-user OAuth: letting your **end users** authorize third-party services (e.g. Gmail) so their integration can be bound to an MCP server you deploy. It is **not** about authenticating a client to a Blaxel MCP endpoint, as deployed Blaxel MCP servers only use bearer tokens, not OAuth.
+</Warning>
+
+Some Blaxel integrations support [OAuth](https://oauth.net/2/)-based authentication. You can automate such a flow to allow multiple users (tenants) to go through an OAuth flow and each have their integration.
 
 This approach is particularly useful when you need to automate the creation of dedicated MCP servers for each tenant with customized access permissions. This guide takes the example of creating such a flow for a [Gmail integration](/Integrations/Gmail).
 
@@ -103,7 +107,7 @@ def exchange_code_for_tokens(auth_code, client_id, client_secret, redirect_uri):
     Exchange authorization code for access and refresh tokens
     """
     token_url = "https://oauth2.googleapis.com/token"
-    
+
     data = {
         'code': auth_code,
         'client_id': client_id,
@@ -111,19 +115,19 @@ def exchange_code_for_tokens(auth_code, client_id, client_secret, redirect_uri):
         'redirect_uri': redirect_uri,
         'grant_type': 'authorization_code'
     }
-    
+
     try:
         response = requests.post(token_url, data=data)
         response.raise_for_status()
-        
+
         token_data = response.json()
-        
+
         return {
             'access_token': token_data['access_token'],
             'refresh_token': token_data['refresh_token'],
             'expires_in': token_data['expires_in']
         }
-    
+
     except requests.exceptions.RequestException as e:
         print(f"Token exchange failed: {e}")
         if hasattr(e.response, 'json'):

--- a/Sandboxes/MCP.mdx
+++ b/Sandboxes/MCP.mdx
@@ -13,7 +13,7 @@ The MCP server operates through streamable HTTP at the sandbox's base URL:
 https://<SANDBOX_BASE_URL>/mcp
 ```
 
-The base URL of a sandbox can be [retrieved](https://docs.blaxel.ai/api-reference/compute/get-sandbox) via the management API of sandboxes under `metadata.url`.
+The base URL of a sandbox can be [retrieved](https://docs.blaxel.ai/api-reference/compute/get-sandbox) via the management API of sandboxes under `metadata.url` or via the Blaxel [SDKs](/Sandboxes/Overview#retrieve-an-existing-sandbox).
 
 Connect to this MCP server [like any other MCP server](../Functions/Invoke-functions) through the endpoint shown above. Instructions for some popular applications are provided below.
 
@@ -23,6 +23,10 @@ Connect to this MCP server [like any other MCP server](../Functions/Invoke-funct
   - Required: `Authorization: Bearer <APIKEY>`
   - Optional (multi-workspace): `X-Blaxel-Workspace: <WORKSPACE_NAME_OR_ID>`
 </Note>
+
+<Tip>
+  Bearer-token authentication only — there is no OAuth for connecting to the sandbox MCP endpoint. See [MCP endpoints at a glance](/skills-mcp#mcp-endpoints-at-a-glance) for how this compares to the other MCP surfaces on Blaxel.
+</Tip>
 
 ### Add to Cursor
 

--- a/skills-mcp.mdx
+++ b/skills-mcp.mdx
@@ -231,6 +231,23 @@ claude mcp add --transport http blaxel-docs https://docs.blaxel.ai/mcp
 }
 ```
 
+### MCP server for sandboxes
+
+Every Blaxel sandbox also exposes its own built-in [MCP server](/Sandboxes/MCP), hosted via streamable HTTP at `https://<SANDBOX_BASE_URL>/mcp`, so agents can operate that specific sandbox directly.
+
+### MCP server hosting
+
+Blaxel also lets you deploy and host your [own MCP servers](/Functions/Overview) as serverless, autoscaling endpoints.
+
+### MCP endpoints at a glance
+
+| Surface | Endpoint pattern | Purpose | Persistence |
+| --- | --- | --- | --- |
+| Resource management | `https://api.blaxel.ai/v0/mcp` | Manage your Blaxel workspace (create/list/delete resources) from a coding assistant | Fixed platform endpoint |
+| Documentation | `https://docs.blaxel.ai/mcp` | Give a coding assistant real-time access to this documentation | Fixed platform endpoint |
+| Per deployed MCP server | `https://run.blaxel.ai/{workspace}/functions/{server-name}/mcp` | Call tools exposed by an MCP server deployed by you | Fixed so long as the function's name is unchanged |
+| Per deployed sandbox | `https://<SANDBOX_BASE_URL>/mcp` | Let an agent operate a sandbox deployed by you | Tied to the sandbox's `name`; fixed across standby/resume. |
+
 ## llms-full.txt
 
 A compiled text document of the entire documentation, formatted for LLMs. Copy and paste it directly into your coding assistant's prompt:


### PR DESCRIPTION
Fixes ENG-3835

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Documentation update that clarifies the distinction between bearer-token authentication for Blaxel MCP endpoints and end-user OAuth flows, adds cross-references between different MCP surfaces, and introduces a comparison table summarizing all MCP endpoints.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8a618699cb1126e17b312608e2a313c43874b385.</sup>
<!-- /MENDRAL_SUMMARY -->