### PR TITLE
docs: update sandbox status and troubleshooting

### DIFF
--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -71,6 +71,8 @@ During the deployment process, the possible sandbox statuses are:
 - `DEPLOYING`: The sandbox deployment is in progress.
 - `DEPLOYED`: The sandbox is ready to use. It is either in active mode or standby mode.
 - `FAILED`: An error occurred during the build or deployment of the sandbox.
+- `DEACTIVATING`: The sandbox is being disabled, either because it was explicitly disabled or because a previous revision is being superseded by a new deployment.
+- `DEACTIVATED`: The sandbox has been disabled and is not accepting connections.
 - `TERMINATED`: A TTL was set for the sandbox; it has been deleted and will be removed from the API/UI soon.
 - `DELETING`: A deletion request has been triggered and the deletion is in progress.
 

--- a/Sandboxes/Templates.mdx
+++ b/Sandboxes/Templates.mdx
@@ -1079,7 +1079,8 @@ The `status` field of the response will progress through these values:
 | `DEPLOYING` | Container is being deployed to the cluster |
 | `DEPLOYED` | Sandbox is ready to use |
 | `FAILED` | Deployment failed (check build logs) |
-| `DEACTIVATED` | Sandbox has been deactivated |
+
+See [sandbox deployment statuses](/Sandboxes/Overview#sandbox-deployment-statuses) for the full list of statuses a sandbox can report outside of this initial deployment flow.
 
 Continue polling every 3-5 seconds until the status reaches `DEPLOYED` or `FAILED`.
 

--- a/troubleshooting.mdx
+++ b/troubleshooting.mdx
@@ -61,6 +61,16 @@ The sandbox logs will typically contain additional information to identify the r
 Deleting and recreating will cause the current state of the sandbox to be lost.
 </Note>
 
+## Sandbox creation returns a `504 Gateway Timeout`
+
+This error occurs when a sandbox creation request takes longer than CloudFront's edge timeout (approximately 60 seconds) to complete. CloudFront closes the connection to the origin and returns an HTML `504 Gateway Time-out` page rather than a Blaxel JSON error. This does **not** mean sandbox creation failed; the build and deployment continue in the background.
+
+To resolve this error, poll the sandbox's `status` field until it reaches `DEPLOYED` or `FAILED`, using the polling pattern shown in the [custom image deployment guide](/Sandboxes/Templates#4-monitor-deployment-status).
+
+<Note>
+  The TypeScript SDK's `SandboxInstance.create()` handles this automatically by falling back to polling on a 504, so this only needs manual handling when calling the REST API directly or using other language SDKs.
+</Note>
+
 ## Sandbox deployment fails with `STARTUP TCP probe failed` or `DEADLINE_EXCEEDED` error
 
 This error occurs when the server running inside the sandbox is not binding to the correct host and port.


### PR DESCRIPTION
Fixes ENG-3924

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds two new sandbox deployment statuses (`DEACTIVATING`, `DEACTIVATED`), replaces an inline status table in Templates.mdx with a link to the Overview page, and adds a new troubleshooting section for 504 Gateway Timeout errors during sandbox creation.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0bf901639a71f1b7f7d6f54e29574a3c26e917f2.</sup>
<!-- /MENDRAL_SUMMARY -->