### PR TITLE
docs: improve discoverability of storage options

### DIFF
--- a/Agent-drive/Overview.mdx
+++ b/Agent-drive/Overview.mdx
@@ -18,6 +18,10 @@ Unlike [volumes](/Volumes/Overview), which are block storage devices attached at
 - A specific subdirectory of a drive can be mounted using `drivePath` (instead of mounting the entire drive).
 - Drives scale automatically with no fixed capacity limits. Pre-provisioning or run-time resizing is not required.
 
+<Tip>
+  Refer to our [blog post on choosing the right storage for your Blaxel agents](https://blaxel.ai/blog/choose-the-right-storage-for-your-blaxel-agents) for more informaton.
+</Tip>
+
 ## Use cases
 
 Some examples of use cases are:

--- a/Sandboxes/Filesystem.mdx
+++ b/Sandboxes/Filesystem.mdx
@@ -8,6 +8,10 @@ description: 'Read, write, list, and delete files inside a Blaxel sandbox using 
 
 Manage files and directories within sandboxes through the `fs` module of Blaxel SDK. This module provides essential operations for creating, reading, writing, copying, and deleting files and directories.
 
+<Tip>
+  Refer to our [blog post on choosing the right storage for your Blaxel agents](https://blaxel.ai/blog/choose-the-right-storage-for-your-blaxel-agents) for more informaton.
+</Tip>
+
 <Tip>Complete code examples demonstrating all operations are available on Blaxel's GitHub: [in TypeScript](https://github.com/blaxel-ai/sdk-typescript/tree/main/tests/sandbox), [in Python](https://github.com/blaxel-ai/sdk-python/tree/main/tests/integration/sandbox), and [in Go](https://github.com/blaxel-ai/sdk-go/tree/main/integration_tests).</Tip>
 
 ## Basic file system operations

--- a/Sandboxes/Overview.mdx
+++ b/Sandboxes/Overview.mdx
@@ -252,7 +252,7 @@ For write-heavy workloads, set `storageMb` (TypeScript/CLI) or `storage_mb` (Pyt
 
 `storageMb` cannot be combined with a persistent volume mounted at `/`. Use root storage for ephemeral root filesystem capacity, or use a volume at a subpath such as `/data` when data should persist independently from the sandbox lifecycle.
 
-Use [volumes](/Sandboxes/Volumes) when data needs to live at a specific mount path or persist independently from the sandbox lifecycle. Volumes require deleting and recreating the sandbox first, and are not as fast as the native in-memory filesystem.
+Use [volumes](/Sandboxes/Volumes) when data needs to live at a specific mount path or persist independently from the sandbox lifecycle. Volumes require deleting and recreating the sandbox first, and are not as fast as the native in-memory filesystem. Refer to our [blog post on choosing the right storage for your Blaxel agents](https://blaxel.ai/blog/choose-the-right-storage-for-your-blaxel-agents) for more information.
 
 ### Ports
 

--- a/Sandboxes/best-practices.mdx
+++ b/Sandboxes/best-practices.mdx
@@ -37,9 +37,15 @@ Here's a table to help you decide:
 | Durability | Low (lost on sandbox deletion or crash) | High (block storage, replicated) | High (distributed storage, replicated)
 | Access type | Single | Single | Multiple |
 | Hot-attach | N/A | No | Yes |
-| Interface | POSIX | POSIX | POSIX + S3 |
+| Interface | POSIX | POSIX | POSIX (S3 interface coming soon) |
 | Size | ~50% of sandbox memory by default; configurable with root storage | User-defined at creation, expandable | No size limit |
 | Optimized for | Data that doesn’t require high durability | Data that requires durability with high performance | Shared data |
+
+Refer to our [blog post on choosing the right storage for your Blaxel agents](https://blaxel.ai/blog/choose-the-right-storage-for-your-blaxel-agents) for more informaton.
+
+<Note>
+  No storage option currently supports mounting external storage (such as S3 buckets) as a filesystem today via s3fs or similar (Agent Drive's S3 interface is planned but not yet available). There is also no built-in way to bulk-sync files between a sandbox and your local machine. Instead, use [`sandbox.fs.download()`](/Sandboxes/Filesystem#download-file-to-host) for single files, or the zip-upload-unzip pattern in the next section for bulk transfers.
+</Note>
 
 ## Upload many files efficiently
 

--- a/Volumes/Overview.mdx
+++ b/Volumes/Overview.mdx
@@ -12,6 +12,10 @@ While Blaxel automatically snapshots the full state of a sandbox at scale down a
 
 Volumes use block storage and can only be accessed by attaching them to a running sandbox or agent. They cannot be mounted locally on your machine. Blaxel also does not support mounting external storage (such as S3 buckets) as volumes.
 
+<Tip>
+  Refer to our [blog post on choosing the right storage for your Blaxel agents](https://blaxel.ai/blog/choose-the-right-storage-for-your-blaxel-agents) for more informaton.
+</Tip>
+
 ## Create a volume
 
 To create a standalone volume, you must provide a unique `name` and specify its `size` in megabytes (MB). You can also specify optional labels. This volume exists independently of any resource it may later be attached to.

--- a/troubleshooting.mdx
+++ b/troubleshooting.mdx
@@ -122,7 +122,7 @@ To resolve this error, choose the storage option that matches the workload:
 - Add storage using [volumes](/Sandboxes/Volumes) when data should live at a specific mount path or persist independently from the sandbox lifecycle. Adding storage requires deleting and recreating the sandbox first.
 
     <Note>
-    Volumes are slower than the in-memory filesystem.
+    Volumes are slower than the in-memory filesystem. Refer to our [blog post on choosing the right storage for your Blaxel agents](https://blaxel.ai/blog/choose-the-right-storage-for-your-blaxel-agents) for our benchmarks.
     </Note>
 
 ## Sandbox commands return a `404 WORKSPACE_NOT_FOUND` error


### PR DESCRIPTION
Fixes ENG-3925

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds cross-references to a blog post about storage options across multiple documentation pages (Agent Drive, Sandboxes, Volumes, troubleshooting). Also adds a note clarifying current storage limitations and updates the comparison table to reflect that the S3 interface is "coming soon" rather than available.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 5e5044b25870821fd478b52f61533256402335d6.</sup>
<!-- /MENDRAL_SUMMARY -->