### PR TITLE
Update Homebrew install instructions for tap trust

### DIFF
--- a/Functions/Adapt-Existing-MCP-server.mdx
+++ b/Functions/Adapt-Existing-MCP-server.mdx
@@ -17,16 +17,12 @@ Follow the steps below for your platform.
 <AccordionGroup>
 <Accordion title="Install on Mac" icon="apple">
 
-<Warning>To install Blaxel CLI, you must use [Homebrew](https://brew.sh/): make sure it is installed on your machine. We are currently in the process of supporting additional installers. Check out the cURL method down below for general installation.</Warning>
+<Warning>To install Blaxel CLI with Homebrew, make sure [Homebrew](https://brew.sh/) is installed on your machine. Homebrew 6.0.0+ requires explicit trust for non-official taps, so use the fully qualified formula name below. We are currently in the process of supporting additional installers. Check out the cURL method down below for general installation.</Warning>
 
-Install Blaxel CLI by running the two following commands successively in a terminal:
-
-```bash
-brew tap blaxel-ai/blaxel
-```
+Install Blaxel CLI by running the following command in a terminal:
 
 ```bash
-brew install blaxel
+brew install blaxel-ai/blaxel/blaxel
 ```
 
 </Accordion>

--- a/Get-started.mdx
+++ b/Get-started.mdx
@@ -30,20 +30,12 @@ Welcome there! 👋 Make sure you have created an account on Blaxel (here → [h
 
 <Accordion title="Install on Mac" icon="apple">
 
-<Warning>To install Blaxel CLI, you must use [Homebrew](https://brew.sh/): make sure it is installed on your machine. We are currently in the process of supporting additional installers. Check out the cURL method down below for general installation.</Warning>
+<Warning>To install Blaxel CLI with Homebrew, make sure [Homebrew](https://brew.sh/) is installed on your machine. Homebrew 6.0.0+ requires explicit trust for non-official taps, so use the fully qualified formula name below. We are currently in the process of supporting additional installers. Check out the cURL method down below for general installation.</Warning>
 
-Install Blaxel CLI by running the two following commands successively in a terminal:
-
-```shell
-
-brew tap blaxel-ai/blaxel
-
-```
+Install Blaxel CLI by running the following command in a terminal:
 
 ```shell
-
-brew install blaxel
-
+brew install blaxel-ai/blaxel/blaxel
 ```
 
 </Accordion>

--- a/cli-reference/introduction.mdx
+++ b/cli-reference/introduction.mdx
@@ -11,21 +11,13 @@ Blaxel CLI (`bl`) is a command line tool to interact with the Blaxel APIs.
 <AccordionGroup>
   <Accordion title="Install on Mac" icon="apple">
     <Warning>
-      To install Blaxel CLI, you must use [Homebrew](https://brew.sh/): make sure it is installed on your machine. We are currently in the process of supporting additional installers. Check out the cURL method down below for general installation.
+      To install Blaxel CLI with Homebrew, make sure [Homebrew](https://brew.sh/) is installed on your machine. Homebrew 6.0.0+ requires explicit trust for non-official taps, so use the fully qualified formula name below. We are currently in the process of supporting additional installers. Check out the cURL method down below for general installation.
     </Warning>
 
-    Install Blaxel CLI by running the two following commands successively in a terminal:
+    Install Blaxel CLI by running the following command in a terminal:
 
     ```shell
-
-    brew tap blaxel-ai/blaxel
-
-    ```
-
-    ```shell
-
-    brew install blaxel
-
+    brew install blaxel-ai/blaxel/blaxel
     ```
   </Accordion>
 


### PR DESCRIPTION
Fixes ENG-3947

**What this is:** Updates the macOS Homebrew install docs for Homebrew 6.0.0 tap trust behavior.

**The problem:** Homebrew 6.0.0 requires explicit trust for non-official taps, so the old `brew tap blaxel-ai/blaxel` plus short-name install flow can fail.

**What it changes:**
- Uses the fully qualified formula install command: `brew install blaxel-ai/blaxel/blaxel`
- Keeps the existing note about additional installers and the cURL option
- Applies the same macOS install wording across the quickstart, CLI overview, and MCP quickstart

Reference: https://docs.brew.sh/Tap-Trust